### PR TITLE
Replace build status badge pointing to .org travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Expandable RecyclerView
-[![Build Status](https://magnum.travis-ci.com/bignerdranch/expandable-recycler-view.svg?token=cHtfwvsfoiWYD2CaiRkc&branch=master)](https://magnum.travis-ci.com/bignerdranch/expandable-recycler-view)
+[![Build Status](https://travis-ci.org/bignerdranch/expandable-recycler-view.svg)](https://travis-ci.org/bignerdranch/expandable-recycler-view)
 
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Expandable%20RecyclerView-green.svg?style=flat)](https://android-arsenal.com/details/1/2119)
 


### PR DESCRIPTION
Clicked some buttons over at travis-ci.org, this should get the build going again.