### PR TITLE
remove unnecessary type checking

### DIFF
--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -26,11 +26,7 @@ public class ExpandableRecyclerAdapterHelper {
     }
 
     public Object getHelperItemAtPosition(int position) {
-        if (mHelperItemList.get(position) instanceof ParentWrapper) {
-            return mHelperItemList.get(position);
-        } else {
-            return mHelperItemList.get(position);
-        }
+        return mHelperItemList.get(position);
     }
 
     public List<Object> generateHelperItemList(List<Object> itemList) {


### PR DESCRIPTION
I noticed this method checking type in a situation where it doesn't seem needed.