### PR TITLE
Allow items to be expanded initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,37 @@ Javadocs for the library and sample are available [here](http://bignerdranch.git
  
  Then, create two ViewHolders and their respective layouts. One ViewHolder must extend ```ParentViewHolder``` and the other must extend ```ChildViewHolder```. Create their respective views and create variables in these ViewHolders to access those views.
  
- Next, the Object that contains the data to be displayed in your RecyclerView must extend ```ParentObject```
+ Next, the Object that contains the data to be displayed in your RecyclerView must extend ```ParentObject```. When you implement ```ParentObject``` there are three methods that you must implement, shown in the example below:
+ ```java
+ public class MyCustomParentObject implements ParentObject {
+     private List<Object> mChildObjectList;
+
+     /**
+      * Your constructors, variables, data and methods for your Object go here
+      */
+
+     @Override
+     public List<Object> getChildObjectList() {
+         /**
+          * You can either return a newly created list of children here or attach them later
+          */
+
+         return mChildObjectList;
+     }
+
+     @Override
+     public void setChildObjectList(List<Object> childObjectList) {
+         mChildObjectList = childObjectList;
+     }
+
+     @Override
+     public boolean isInitiallyExpanded() {
+         // Allows you to specify if the row should be expanded when first shown to the user
+         return false;
+     }
+ }
+ ```
+ When generating the list of parent objects, you should attach all children to them there. If the children share data with your ```ParentObject```, you can simply create a list of children in the constructor for your parent object or in the getter method for the list.
 
  In onCreate or onCreateView of your activity or fragment, create and attach your custom expandable adapter like so:
  
@@ -65,32 +95,7 @@ mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
  Inside your ExpandableRecyclerAdapter, you can create and bind your Parent and Child ViewHolders just as you would create and bind ViewHolders in a normal RecyclerView.
 
- Then, define a parent object and implement ```ParentObject```. It is also best practice to create a separate child object to store any data that you need to display in the child view, but it is not required. When you implement ```ParentObject```, you need to create an instance variable, List<Object>, to store all the children of the parent object in. The list must be type casted to Object. If it is null or empty, no child will be shown.
- 
-```java
-public class MyCustomParentObject implements ParentObject {
-    private List<Object> mChildObjectList;
-    
-    /**
-     * Your constructors, variables, data and methods for your Object go here
-     */
-    
-    @Override
-    public List<Object> getChildObject() {
-        /**
-         * You can either return a newly created list of children here or attach them later
-         */
-     
-        return mChildObjectList;
-    }
-    
-    @Override
-    public void setChildObject(List<Object> childObjectList) {
-        mChildObjectList = childObjectList;
-    }
-}
-```
-When generating the list of parent objects, you should attach all children to them there. If the children share data with your ```ParentObject```, you can simply create a list of children in the constructor for your parent object or in the getter method for the list.
+
  
 #### Extras
  You can define a custom button, image or view to trigger the expansion rather than clicking the whole item (default). To do this, in your activity or fragment, call ```myCustomExpandingAdapter.setCustomClickableView(Your Custom View ID)``` and pass in the id.

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/CustomParentObject.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/CustomParentObject.java
@@ -20,7 +20,7 @@ public class CustomParentObject implements ParentObject {
 
     private String mParentText;
     private int mParentNumber;
-    private boolean mInitiallyExpand;
+    private boolean mInitiallyExpanded;
 
 
     public CustomParentObject() {
@@ -64,10 +64,10 @@ public class CustomParentObject implements ParentObject {
 
     @Override
     public boolean isInitiallyExpanded() {
-        return mInitiallyExpand;
+        return mInitiallyExpanded;
     }
 
-    public void setInitiallyExpand(boolean initiallyExpand) {
-        mInitiallyExpand = initiallyExpand;
+    public void setInitiallyExpanded(boolean initiallyExpanded) {
+        mInitiallyExpanded = initiallyExpanded;
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/CustomParentObject.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/CustomParentObject.java
@@ -20,6 +20,7 @@ public class CustomParentObject implements ParentObject {
 
     private String mParentText;
     private int mParentNumber;
+    private boolean mInitiallyExpand;
 
 
     public CustomParentObject() {
@@ -59,5 +60,14 @@ public class CustomParentObject implements ParentObject {
     @Override
     public void setChildObjectList(List<Object> childObjectList) {
         mChildObjectList = childObjectList;
+    }
+
+    @Override
+    public boolean isInitiallyExpanded() {
+        return mInitiallyExpand;
+    }
+
+    public void setInitiallyExpand(boolean initiallyExpand) {
+        mInitiallyExpand = initiallyExpand;
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/VerticalLinearRecyclerViewSample.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/VerticalLinearRecyclerViewSample.java
@@ -195,7 +195,7 @@ public class VerticalLinearRecyclerViewSample extends AppCompatActivity implemen
             customParentObject.setParentNumber(i);
             customParentObject.setParentText(PARENT_TEXT + i);
             if (i == 0) {
-                customParentObject.setInitiallyExpand(true);
+                customParentObject.setInitiallyExpanded(true);
             }
             parentObjectList.add(customParentObject);
         }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/VerticalLinearRecyclerViewSample.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/VerticalLinearRecyclerViewSample/VerticalLinearRecyclerViewSample.java
@@ -194,6 +194,9 @@ public class VerticalLinearRecyclerViewSample extends AppCompatActivity implemen
             customParentObject.setChildObjectList(childObjectList);
             customParentObject.setParentNumber(i);
             customParentObject.setParentText(PARENT_TEXT + i);
+            if (i == 0) {
+                customParentObject.setInitiallyExpand(true);
+            }
             parentObjectList.add(customParentObject);
         }
         return parentObjectList;

--- a/criminalintentsample/build.gradle
+++ b/criminalintentsample/build.gradle
@@ -21,8 +21,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile project(':expandablerecyclerview')
     compile 'com.android.support:support-v4:22.1.0'
     compile 'com.android.support:recyclerview-v7:22.1.0'
     compile 'com.android.support:appcompat-v7:22.1.0'
-    compile 'com.bignerdranch.android:expandablerecyclerview:1.0.3'
 }

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/Crime.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/Crime.java
@@ -2,7 +2,6 @@ package com.bignerdranch.android.criminalintent;
 
 import com.bignerdranch.expandablerecyclerview.Model.ParentObject;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -56,5 +55,10 @@ public class Crime implements ParentObject {
     @Override
     public void setChildObjectList(List<Object> list) {
         mChildrenList = list;
+    }
+
+    @Override
+    public boolean isInitiallyExpanded() {
+        return false;
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -38,8 +38,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
     protected Context mContext;
     protected List<ParentObject> mParentItemList;
+    private List<Object> mHelperItemList;
     private HashMap<Long, Boolean> mStableIdMap;
-    private ExpandableRecyclerAdapterHelper mExpandableRecyclerAdapterHelper;
     private ExpandCollapseListener mExpandCollapseListener;
     private boolean mParentAndIconClickable = false;
     private int mCustomParentAnimationViewId = CUSTOM_ANIMATION_VIEW_NOT_SET;
@@ -56,8 +56,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     public ExpandableRecyclerAdapter(Context context, List<ParentObject> parentItemList) {
         mContext = context;
         mParentItemList = parentItemList;
-        mExpandableRecyclerAdapterHelper = new ExpandableRecyclerAdapterHelper(mParentItemList);
-        mStableIdMap = generateStableIdMapFromList(mExpandableRecyclerAdapterHelper.getHelperItemList());
+        mHelperItemList = ExpandableRecyclerAdapterHelper.generateHelperItemList(parentItemList);
+        mStableIdMap = generateStableIdMapFromList(mHelperItemList);
     }
 
     /**
@@ -73,8 +73,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                                      int customParentAnimationViewId) {
         mContext = context;
         mParentItemList = parentItemList;
-        mExpandableRecyclerAdapterHelper = new ExpandableRecyclerAdapterHelper(mParentItemList);
-        mStableIdMap = generateStableIdMapFromList(mExpandableRecyclerAdapterHelper.getHelperItemList());
+        mHelperItemList = ExpandableRecyclerAdapterHelper.generateHelperItemList(parentItemList);
+        mStableIdMap = generateStableIdMapFromList(mHelperItemList);
         mCustomParentAnimationViewId = customParentAnimationViewId;
     }
 
@@ -92,8 +92,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                                      int customParentAnimationViewId, long animationDuration) {
         mContext = context;
         mParentItemList = parentItemList;
-        mExpandableRecyclerAdapterHelper = new ExpandableRecyclerAdapterHelper(mParentItemList);
-        mStableIdMap = generateStableIdMapFromList(mExpandableRecyclerAdapterHelper.getHelperItemList());
+        mHelperItemList = ExpandableRecyclerAdapterHelper.generateHelperItemList(parentItemList);
+        mStableIdMap = generateStableIdMapFromList(mHelperItemList);
         mCustomParentAnimationViewId = customParentAnimationViewId;
         mAnimationDuration = animationDuration;
     }
@@ -138,7 +138,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-        if (mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position) instanceof ParentWrapper) {
+        if (getHelperItem(position) instanceof ParentWrapper) {
             PVH parentViewHolder = (PVH) holder;
 
             if (mParentAndIconClickable) {
@@ -165,12 +165,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 }
             }
 
-            parentViewHolder.setExpanded(((ParentWrapper) mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position)).isExpanded());
-            onBindParentViewHolder(parentViewHolder, position, ((ParentWrapper) mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position)).getParentObject());
-        } else if (mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position) == null) {
+            parentViewHolder.setExpanded(((ParentWrapper) getHelperItem(position)).isExpanded());
+            onBindParentViewHolder(parentViewHolder, position, ((ParentWrapper) getHelperItem(position)).getParentObject());
+        } else if (getHelperItem(position) == null) {
             throw new IllegalStateException("Incorrect ViewHolder found");
         } else {
-            onBindChildViewHolder((CVH) holder, position, mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position));
+            onBindChildViewHolder((CVH) holder, position, getHelperItem(position));
         }
     }
 
@@ -215,7 +215,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     @Override
     public int getItemCount() {
-        return mExpandableRecyclerAdapterHelper.getHelperItemList().size();
+        return mHelperItemList.size();
     }
 
     /**
@@ -227,9 +227,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     @Override
     public int getItemViewType(int position) {
-        if (mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position) instanceof ParentWrapper) {
+        if (getHelperItem(position) instanceof ParentWrapper) {
             return TYPE_PARENT;
-        } else if (mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position) == null) {
+        } else if (getHelperItem(position) == null) {
             throw new IllegalStateException("Null object added");
         } else {
             return TYPE_CHILD;
@@ -244,7 +244,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     @Override
     public void onParentItemClickListener(int position) {
-        Object helperItem = mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position);
+        Object helperItem = getHelperItem(position);
         if (helperItem instanceof ParentWrapper) {
             ParentObject parentObject = ((ParentWrapper) helperItem).getParentObject();
             expandParent(parentObject, position);
@@ -309,7 +309,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * @param position
      */
     private void expandParent(ParentObject parentObject, int position) {
-        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(position);
+        ParentWrapper parentWrapper = (ParentWrapper) getHelperItem(position);
         if (parentWrapper == null) {
             return;
         }
@@ -325,7 +325,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             List<Object> childObjectList = parentWrapper.getParentObject().getChildObjectList();
             if (childObjectList != null) {
                 for (int i = childObjectList.size() - 1; i >= 0; i--) {
-                    mExpandableRecyclerAdapterHelper.getHelperItemList().remove(position + i + 1);
+                    mHelperItemList.remove(position + i + 1);
                     notifyItemRemoved(position + i + 1);
                 }
             }
@@ -341,7 +341,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             List<Object> childObjectList = parentWrapper.getParentObject().getChildObjectList();
             if (childObjectList != null) {
                 for (int i = 0; i < childObjectList.size(); i++) {
-                    mExpandableRecyclerAdapterHelper.getHelperItemList().add(position + i + 1, childObjectList.get(i));
+                    mHelperItemList.add(position + i + 1, childObjectList.get(i));
                     notifyItemInserted(position + i + 1);
                 }
             }
@@ -361,7 +361,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
         int expandedCount = 0;
         for (int i = 0; i < position; i++) {
-            Object object = mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(i);
+            Object object = getHelperItem(i);
             if (!(object instanceof ParentWrapper)) {
                 expandedCount++;
             }
@@ -380,7 +380,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         HashMap<Long, Boolean> parentObjectHashMap = new HashMap<>();
         for (int i = 0; i < itemList.size(); i++) {
             if (itemList.get(i) != null) {
-                Object helperItem = mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(i);
+                Object helperItem = getHelperItem(i);
                 if (helperItem instanceof ParentWrapper) {
                     ParentWrapper parentWrapper = (ParentWrapper) helperItem;
                     parentObjectHashMap.put(parentWrapper.getStableId(), parentWrapper.isExpanded());
@@ -435,9 +435,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
         mStableIdMap = (HashMap<Long, Boolean>) savedInstanceStateBundle.getSerializable(STABLE_ID_MAP);
         int i = 0;
-        while (i < mExpandableRecyclerAdapterHelper.getHelperItemList().size()) {
-            if (mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(i) instanceof ParentWrapper) {
-                ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapterHelper.getHelperItemAtPosition(i);
+        while (i < mHelperItemList.size()) {
+            if (getHelperItem(i) instanceof ParentWrapper) {
+                ParentWrapper parentWrapper = (ParentWrapper) getHelperItem(i);
                 if (mStableIdMap.containsKey(parentWrapper.getStableId())) {
                     parentWrapper.setExpanded(mStableIdMap.get(parentWrapper.getStableId()));
                     if (parentWrapper.isExpanded() && !parentWrapper.getParentObject().isInitiallyExpanded()) {
@@ -445,13 +445,13 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                         if (childObjectList != null) {
                             for (int j = 0; j < childObjectList.size(); j++) {
                                 i++;
-                                mExpandableRecyclerAdapterHelper.getHelperItemList().add(i, childObjectList.get(j));
+                                mHelperItemList.add(i, childObjectList.get(j));
                             }
                         }
                     } else if (!parentWrapper.isExpanded() && parentWrapper.getParentObject().isInitiallyExpanded()) {
                         List<Object> childObjectList = parentWrapper.getParentObject().getChildObjectList();
                         for (int j = 0; j < childObjectList.size(); j++) {
-                            mExpandableRecyclerAdapterHelper.getHelperItemList().remove(i + 1);
+                            mHelperItemList.remove(i + 1);
                         }
                     }
                 } else {
@@ -461,5 +461,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             i++;
         }
         notifyDataSetChanged();
+    }
+
+    private Object getHelperItem(int position) {
+        return mHelperItemList.get(position);
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -138,7 +138,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-        if (getHelperItem(position) instanceof ParentWrapper) {
+        Object helperItem = getHelperItem(position);
+        if (helperItem instanceof ParentWrapper) {
             PVH parentViewHolder = (PVH) holder;
 
             if (mParentAndIconClickable) {
@@ -165,12 +166,13 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 }
             }
 
-            parentViewHolder.setExpanded(((ParentWrapper) getHelperItem(position)).isExpanded());
-            onBindParentViewHolder(parentViewHolder, position, ((ParentWrapper) getHelperItem(position)).getParentObject());
-        } else if (getHelperItem(position) == null) {
+            ParentWrapper parentWrapper = (ParentWrapper) helperItem;
+            parentViewHolder.setExpanded(parentWrapper.isExpanded());
+            onBindParentViewHolder(parentViewHolder, position, parentWrapper.getParentObject());
+        } else if (helperItem == null) {
             throw new IllegalStateException("Incorrect ViewHolder found");
         } else {
-            onBindChildViewHolder((CVH) holder, position, getHelperItem(position));
+            onBindChildViewHolder((CVH) holder, position, helperItem);
         }
     }
 
@@ -227,9 +229,10 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     @Override
     public int getItemViewType(int position) {
-        if (getHelperItem(position) instanceof ParentWrapper) {
+        Object helperItem = getHelperItem(position);
+        if (helperItem instanceof ParentWrapper) {
             return TYPE_PARENT;
-        } else if (getHelperItem(position) == null) {
+        } else if (helperItem == null) {
             throw new IllegalStateException("Null object added");
         } else {
             return TYPE_CHILD;
@@ -436,8 +439,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         mStableIdMap = (HashMap<Long, Boolean>) savedInstanceStateBundle.getSerializable(STABLE_ID_MAP);
         int i = 0;
         while (i < mHelperItemList.size()) {
-            if (getHelperItem(i) instanceof ParentWrapper) {
-                ParentWrapper parentWrapper = (ParentWrapper) getHelperItem(i);
+            Object helperItem = getHelperItem(i);
+            if (helperItem instanceof ParentWrapper) {
+                ParentWrapper parentWrapper = (ParentWrapper) helperItem;
                 if (mStableIdMap.containsKey(parentWrapper.getStableId())) {
                     parentWrapper.setExpanded(mStableIdMap.get(parentWrapper.getStableId()));
                     if (parentWrapper.isExpanded() && !parentWrapper.getParentObject().isInitiallyExpanded()) {

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -16,7 +16,7 @@ public class ExpandableRecyclerAdapterHelper {
     private List<Object> mHelperItemList;
     private static int sCurrentId;
 
-    public ExpandableRecyclerAdapterHelper(List<Object> itemList) {
+    public ExpandableRecyclerAdapterHelper(List<? extends ParentObject> itemList) {
         sCurrentId = INITIAL_STABLE_ID;
         mHelperItemList = generateHelperItemList(itemList);
     }
@@ -29,15 +29,17 @@ public class ExpandableRecyclerAdapterHelper {
         return mHelperItemList.get(position);
     }
 
-    public List<Object> generateHelperItemList(List<Object> itemList) {
+    public List<Object> generateHelperItemList(List<? extends ParentObject> itemList) {
         ArrayList<Object> parentWrapperList = new ArrayList<>();
         for (int i = 0; i < itemList.size(); i++) {
-            if (itemList.get(i) instanceof ParentObject) {
-                ParentWrapper parentWrapper = new ParentWrapper(itemList.get(i), sCurrentId);
-                sCurrentId++;
-                parentWrapperList.add(parentWrapper);
-            } else {
-                parentWrapperList.add(itemList.get(i));
+            ParentObject parentObject = itemList.get(i);
+            ParentWrapper parentWrapper = new ParentWrapper(parentObject, sCurrentId);
+            sCurrentId++;
+            parentWrapperList.add(parentWrapper);
+            if (parentObject.isInitiallyExpanded()) {
+                for (int j = 0; j < parentObject.getChildObjectList().size(); j++) {
+                    parentWrapperList.add(parentObject.getChildObjectList().get(j));
+                }
             }
         }
         return parentWrapperList;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -21,6 +21,7 @@ public class ExpandableRecyclerAdapterHelper {
             sCurrentId++;
             parentWrapperList.add(parentWrapper);
             if (parentObject.isInitiallyExpanded()) {
+                parentWrapper.setExpanded(true);
                 for (int j = 0; j < parentObject.getChildObjectList().size(); j++) {
                     parentWrapperList.add(parentObject.getChildObjectList().get(j));
                 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -10,26 +10,10 @@ import java.util.List;
  * Created by Ryan Brooks on 6/11/15.
  */
 public class ExpandableRecyclerAdapterHelper {
-    private static final String TAG = ExpandableRecyclerAdapterHelper.class.getSimpleName();
-    private static final int INITIAL_STABLE_ID = 0;
-
-    private List<Object> mHelperItemList;
     private static int sCurrentId;
 
-    public ExpandableRecyclerAdapterHelper(List<? extends ParentObject> itemList) {
-        sCurrentId = INITIAL_STABLE_ID;
-        mHelperItemList = generateHelperItemList(itemList);
-    }
 
-    public List<Object> getHelperItemList() {
-        return mHelperItemList;
-    }
-
-    public Object getHelperItemAtPosition(int position) {
-        return mHelperItemList.get(position);
-    }
-
-    public List<Object> generateHelperItemList(List<? extends ParentObject> itemList) {
+    public static List<Object> generateHelperItemList(List<? extends ParentObject> itemList) {
         ArrayList<Object> parentWrapperList = new ArrayList<>();
         for (int i = 0; i < itemList.size(); i++) {
             ParentObject parentObject = itemList.get(i);
@@ -42,6 +26,7 @@ public class ExpandableRecyclerAdapterHelper {
                 }
             }
         }
+        sCurrentId = 0;
         return parentWrapperList;
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentObject.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentObject.java
@@ -34,7 +34,6 @@ public interface ParentObject {
 
     /**
      * Used to determine whether parent view should show up initially as expanded.
-     * Should not be changed once the adapter is created
      *
      * @return true if parent should be expanded
      */

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentObject.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentObject.java
@@ -31,4 +31,12 @@ public interface ParentObject {
      * @param childObjectList
      */
     void setChildObjectList(List<Object> childObjectList);
+
+    /**
+     * Used to determine whether parent view should show up initially as expanded.
+     * Should not be changed once the adapter is created
+     *
+     * @return true if parent should be expanded
+     */
+    boolean isInitiallyExpanded();
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -23,11 +23,11 @@ public class ParentWrapper {
     }
 
     public boolean isExpanded() {
-        return mIsExpanded != mParentObject.isInitiallyExpanded();
+        return mIsExpanded;
     }
 
     public void setExpanded(boolean isExpanded) {
-        mIsExpanded = isExpanded != mParentObject.isInitiallyExpanded();
+        mIsExpanded = isExpanded;
     }
 
     public long getStableId() {

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -6,28 +6,28 @@ package com.bignerdranch.expandablerecyclerview.Model;
 public class ParentWrapper {
     private boolean mIsExpanded;
     private long mStableId;
-    private Object mParentObject;
+    private ParentObject mParentObject;
 
-    public ParentWrapper(Object parentObject, int stableId) {
+    public ParentWrapper(ParentObject parentObject, int stableId) {
         mParentObject = parentObject;
         mStableId = stableId;
         mIsExpanded = false;
     }
 
-    public Object getParentObject() {
+    public ParentObject getParentObject() {
         return mParentObject;
     }
 
-    public void setParentObject(Object parentObject) {
+    public void setParentObject(ParentObject parentObject) {
         mParentObject = parentObject;
     }
 
     public boolean isExpanded() {
-        return mIsExpanded;
+        return mIsExpanded != mParentObject.isInitiallyExpanded();
     }
 
     public void setExpanded(boolean isExpanded) {
-        mIsExpanded = isExpanded;
+        mIsExpanded = isExpanded != mParentObject.isInitiallyExpanded();
     }
 
     public long getStableId() {


### PR DESCRIPTION
Introduces a new method that allows for a Parent Object to initially show up as expanded.
Also cleaned up some casts and duplicated lists in the expanded adapter.

@rbro112 if you have time would like your opinion on some of the changes in ExpandableRecyclerAdapter

Fixes #36 