### PR TITLE
Rotation Removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 2.0.0 SNAPSHOT
 - Added `ExpandCollapseListener`
 - Removed `setChildObjectList` from `ParentObject` interface
 - Remove application tag from manifest
+- Removed animation and click handling details from the adapter, `ParentViewHolder` now has methods required for implementing that behaviour in your own subclasses (examples given in the samples with this library)
 - README updates
 - Bug fixes: [#42](https://github.com/bignerdranch/expandable-recycler-view/pull/42), [#46](https://github.com/bignerdranch/expandable-recycler-view/pull/46), [#47](https://github.com/bignerdranch/expandable-recycler-view/pull/47)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ compile 'com.bignerdranch.android:expandablerecyclerview:1.0.3'
 
 Current development can be found at the following snapshot:
 ```gradle
-compile 'com.bignerdranch.android:expandablerecyclerview:1.1.0-SNAPSHOT'
+compile 'com.bignerdranch.android:expandablerecyclerview:2.0.0-SNAPSHOT'
 ```
 Add Sonatype's snapshots to your repositories closure in the root `build.gradle`:
 ```gradle
@@ -89,18 +89,17 @@ mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
  Inside your ExpandableRecyclerAdapter, you can create and bind your Parent and Child ViewHolders just as you would create and bind ViewHolders in a normal RecyclerView.
 
-
  
-#### Extras
- You can define a custom button, image or view to trigger the expansion rather than clicking the whole item (default). To do this, ParentViewHolder implementation override `shouldItemViewClickToggleExpansion()` to return false. Then in your implementation set an onClickListener to your custom view and call `toggleExpansion()` to trigger the expansion.
+#### View Behaviours
+ You can define a custom button, image or view to trigger the expansion rather than clicking the whole item (default). To do this, your ParentViewHolder implementation should override `shouldItemViewClickToggleExpansion()` to return false. Then in your implementation set an onClickListener to your custom view and call `toggleExpansion()` to trigger the expansion.
  
- You can also create your own animations for expansion by overriding `onExpansionToggled(boolean isExpanded)` which will be called for you when the itemView is expanded or collapsed
+ You can also create your own animations for expansion by overriding `onExpansionToggled(boolean isExpanded)` which will be called for you when the itemView is expanded or collapsed.
 
- The `VerticalLinearRecyclerViewSampleActivity` sample shows a rotation animation in response to expansion changing. 'HorizontalLinearRecyclerViewSampleActivity` sample shows defining your own click target for expansion.
+ The `VerticalLinearRecyclerViewSampleActivity` sample shows a rotation animation in response to expansion changing. `HorizontalLinearRecyclerViewSampleActivity` sample shows defining your own click target for expansion.
  
 #### Listening for Expansion and Collapsing
 
-You can listen for expansion and collapsing events by implementing ```ExpandCollapseListener``` in the activity or fragment hosting your RecyclerView. Two methods will be added, ```onRecyclerViewItemExpanded(int position)``` and ```onRecyclerViewItemCollapsed(int position)```. This will allow you to listen for expansion and collapsing of ParentObjects. The position passed into these methods is the position of the item in the ParentObject list. Any expanded children before the item are not included in that position integer.
+ `onExpansionToggled(boolean isExpanded)` is useful for view changes, but if there are controller level changes (database persistence, web requests etc) you can listen for expansion and collapsing events by implementing ```ExpandCollapseListener``` in the activity or fragment hosting your RecyclerView. The interface contains two methods, ```onRecyclerViewItemExpanded(int position)``` and ```onRecyclerViewItemCollapsed(int position)```. This will allow you to listen for expansion and collapsing of ParentObjects. The position passed into these methods is the position of the item in the ParentObject list. Any expanded children before the item are not included in that position integer.
 
 As an example, let's say we implemented ```ExpandCollapseListener``` in an activity. For this to work, after creating the adapter and before setting the RecyclerView's adapter, we must call ```addExpandCollapseListener(ExpandCollapseListener yourExpandCollapseListener``` on the adapter:
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ Javadocs for the library and sample are available [here](http://bignerdranch.git
      }
 
      @Override
-     public void setChildObjectList(List<Object> childObjectList) {
-         mChildObjectList = childObjectList;
-     }
-
-     @Override
      public boolean isInitiallyExpanded() {
          // Allows you to specify if the row should be expanded when first shown to the user
          return false;
@@ -87,7 +82,7 @@ Javadocs for the library and sample are available [here](http://bignerdranch.git
  
 ```java
 RecyclerView mRecyclerView = (RecyclerView) findViewById(YOUR RECYCLERVIEW ID);
-MyExpandable mExpandableAdapter = new MyExpandableAdapter(getActivity(), YOUR ParentObject LIST);
+MyExpandable mExpandableAdapter = new MyExpandableAdapter(getActivity(), YOUR_ParentObject_LIST);
 mRecyclerView.setAdapter(mExpandableAdapter);
 mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 ```
@@ -97,20 +92,11 @@ mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
  
 #### Extras
- You can define a custom button, image or view to trigger the expansion rather than clicking the whole item (default). To do this, in your activity or fragment, call ```myCustomExpandingAdapter.setCustomClickableView(Your Custom View ID)``` and pass in the id.
+ You can define a custom button, image or view to trigger the expansion rather than clicking the whole item (default). To do this, ParentViewHolder implementation override `shouldItemViewClickToggleExpansion()` to return false. Then in your implementation set an onClickListener to your custom view and call `toggleExpansion()` to trigger the expansion.
  
- If you do set a custom clickable view, you can also set an animation for the view to rotate 180 degrees when expanding and collapsing. This is useful primarily with arrows which signifies for the user to click it to change the expansion. By default the rotation is off. You can enable rotation by calling ```myCustomExpandingAdapter.setRotation(long durationInMS)``` in the constructor, below where you called ```setCustomClickableView()```. When setting the rotation, you must pass in a duration in Milliseconds. If you'd like to use the default rotation duration rather than defining your own, call ```myCustomExpandingAdapter.setParentClickableViewAnimationDefaultDuration()``` instead. The default rotation duration is 200 ms.
- 
- After implementing these, in the activity or fragment that is holding your RecyclerView, simply set the adapter to your custom adapter, and set the layout manager to a new LinearLayoutManager. An example is here:
- 
- ```java
- MyCustomExpandingAdapter myCustomExpandingAdapter = new MyCustomExpandingAdapter(this, objectList);
- 
- // Optional animation configuration goes here
- 
- mRecyclerView.setAdapter(myCustomExpandingAdapter);
- mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
- ```
+ You can also create your own animations for expansion by overriding `onExpansionToggled(boolean isExpanded)` which will be called for you when the itemView is expanded or collapsed
+
+ The `VerticalLinearRecyclerViewSampleActivity` sample shows a rotation animation in response to expansion changing. 'HorizontalLinearRecyclerViewSampleActivity` sample shows defining your own click target for expansion.
  
 #### Listening for Expansion and Collapsing
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,14 +16,14 @@
             </intent-filter>
         </activity>
         <activity
-            android:label="@string/activity_main_vertical_linear_sample_button"
+            android:label="@string/activity_vertical_linear_sample_title"
             android:name=".linear.vertical.VerticalLinearRecyclerViewSampleActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity" />
         </activity>
         <activity
-            android:label="@string/activity_main_horizontal_linear_sample_button"
+            android:label="@string/activity_horizontal_linear_sample_title"
             android:name=".linear.horizontal.HorizontalLinearRecyclerViewSampleActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,12 +16,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:label="@string/activity_main_vertical_linear_sample_button"
             android:name=".linear.vertical.VerticalLinearRecyclerViewSampleActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity" />
         </activity>
         <activity
+            android:label="@string/activity_main_horizontal_linear_sample_button"
             android:name=".linear.horizontal.HorizontalLinearRecyclerViewSampleActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -2,21 +2,15 @@ package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.Spinner;
 import android.widget.Toast;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
 import com.bignerdranch.expandablerecyclerview.ClickListeners.ExpandCollapseListener;
 import com.bignerdranch.expandablerecyclerview.Model.ParentObject;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
@@ -25,17 +19,12 @@ import java.util.ArrayList;
 
 public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivity implements ExpandCollapseListener {
 
-    private static final long INITIAL_ROTATION_SPEED_MS = 100;
-    private static final int NUM_ANIMATION_DURATIONS = 10;
     private static final int NUM_TEST_DATA_ITEMS = 20;
 
     private Toolbar mToolbar;
     private RecyclerView mRecyclerView;
-    private CheckBox mAnimationEnabledCheckBox;
-    private Spinner mToolbarSpinner;
 
     private HorizontalExpandableAdapter mExpandableAdapter;
-    private ArrayList<Long> mDurationList;
 
     public static Intent newIntent(Context context) {
         return new Intent(context, HorizontalLinearRecyclerViewSampleActivity.class);
@@ -51,15 +40,6 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
 
         mRecyclerView = (RecyclerView) findViewById(R.id.activity_horizontal_linear_recycler_view_sample_recyclerView);
 
-        mAnimationEnabledCheckBox = (CheckBox) findViewById(R.id.toolbar_sample_checkBox);
-        mAnimationEnabledCheckBox.setOnCheckedChangeListener(mAnimationEnabledCheckedChangeListener);
-
-        mToolbarSpinner = (Spinner) findViewById(R.id.toolbar_sample_spinner);
-        mToolbarSpinner.setOnItemSelectedListener(mToolbarSpinnerItemSelectListener);
-
-        // Generate spinner's list of rotation speeds (in ms)
-        mDurationList = generateSpinnerSpeeds();
-
         // Create a new adapter with 20 test data items
         mExpandableAdapter = new HorizontalExpandableAdapter(this, setUpTestData(NUM_TEST_DATA_ITEMS));
 
@@ -70,10 +50,6 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         mRecyclerView.setAdapter(mExpandableAdapter);
         // Set the layout manager to a LinearLayout manager for vertical list
         mRecyclerView.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
-
-        // Set spinner adapter
-        HorizontalSpinnerAdapter customSpinnerAdapter = new HorizontalSpinnerAdapter(this, mDurationList);
-        mToolbarSpinner.setAdapter(customSpinnerAdapter);
     }
 
     /**
@@ -108,81 +84,11 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         Toast.makeText(this, toastMessage, Toast.LENGTH_SHORT).show();
     }
 
-    private CompoundButton.OnCheckedChangeListener mAnimationEnabledCheckedChangeListener = new CompoundButton.OnCheckedChangeListener() {
-        @Override
-        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-            if (isChecked) { // Only the custom triggering view can trigger expansion
-                mExpandableAdapter.setParentAndIconExpandOnClick(false);
-            } else { // Both the custom triggering view and the parent item can trigger expansion
-                mExpandableAdapter.setParentAndIconExpandOnClick(true);
-            }
-
-            mExpandableAdapter.setCustomParentAnimationViewId(R.id.list_item_parent_horizontal_arrow_imageView);
-            mExpandableAdapter.setParentClickableViewAnimationDuration((Long) mToolbarSpinner.getSelectedItem());
-            mExpandableAdapter.notifyDataSetChanged();
-        }
-    };
-
-    private AdapterView.OnItemSelectedListener mToolbarSpinnerItemSelectListener = new AdapterView.OnItemSelectedListener() {
-        @Override
-        public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-            if (mAnimationEnabledCheckBox.isChecked()) {
-                enableCustomExpandButton(position);
-            } else {
-                disableCustomExpandButton(position);
-            }
-
-            mExpandableAdapter.notifyDataSetChanged();
-        }
-
-        @Override
-        public void onNothingSelected(AdapterView<?> parent) {
-            // Do nothing
-        }
-    };
-
     private void setupToolbar() {
         setSupportActionBar(mToolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setDisplayHomeAsUpEnabled(true);
-        }
-    }
-
-    /**
-     * Only the custom triggering view triggers expansion
-     */
-    private void enableCustomExpandButton(int animationDurationPosition) {
-        if (mDurationList.get(animationDurationPosition) == 0) {
-            // Sets the rotation animation to off
-            mExpandableAdapter.setParentClickableViewAnimationDuration(
-                    ExpandableRecyclerAdapter.CUSTOM_ANIMATION_DURATION_NOT_SET);
-        } else {
-            // Sets the animation duration to the corresponding duration at the selected position
-            mExpandableAdapter.setParentClickableViewAnimationDuration(mDurationList.get(animationDurationPosition));
-        }
-        // Disables clicking of both the item and the custom clickable view declared by the user
-        mExpandableAdapter.setParentAndIconExpandOnClick(false);
-    }
-
-    /**
-     * Both the custom triggering view and the parent item trigger expansion when clicked
-     */
-    private void disableCustomExpandButton(int animationDurationPosition) {
-        if (mDurationList.get(animationDurationPosition) == 0) {
-            // Sets the rotation animation to off
-            mExpandableAdapter.setParentClickableViewAnimationDuration(
-                    ExpandableRecyclerAdapter.CUSTOM_ANIMATION_DURATION_NOT_SET);
-            // Disable clicking of both parent and child to trigger expansion/collapsing
-            mExpandableAdapter.setParentAndIconExpandOnClick(false);
-        } else {
-            // Sets the animation duration to the corresponding duration at the selected position
-            mExpandableAdapter.setParentClickableViewAnimationDuration(mDurationList.get(animationDurationPosition));
-            // Sets the custom triggering view to the id of the view
-            mExpandableAdapter.setCustomParentAnimationViewId(R.id.list_item_parent_horizontal_arrow_imageView);
-            // Sets both the custom triggering view and the parent item to trigger expansion
-            mExpandableAdapter.setParentAndIconExpandOnClick(true);
         }
     }
 
@@ -223,21 +129,5 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
             parentObjectList.add(horizontalParentObject);
         }
         return parentObjectList;
-    }
-
-    /**
-     * Method to set up the list of animation durations for the Toolbar's Spinner.
-     * <p/>
-     * The list contains long values that correspond to the length of time (in ms) of the animation.
-     *
-     * @return the list of times (in ms) to be populated into the Toolbar's spinner.
-     */
-    private ArrayList<Long> generateSpinnerSpeeds() {
-        ArrayList<Long> speedList = new ArrayList<>();
-        speedList.add(ExpandableRecyclerAdapter.CUSTOM_ANIMATION_DURATION_NOT_SET);
-        for (int i = 1; i <= NUM_ANIMATION_DURATIONS; i++) {
-            speedList.add(INITIAL_ROTATION_SPEED_MS * i);
-        }
-        return speedList;
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -1,10 +1,14 @@
 package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.os.Build;
 import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.animation.RotateAnimation;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
@@ -18,7 +22,10 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
 public class HorizontalParentViewHolder extends ParentViewHolder {
     private static final float INITIAL_POSITION = 0.0f;
     private static final float ROTATED_POSITION = 180f;
+    private static final float PIVOT_VALUE = 0.5f;
+    private static final long DEFAULT_ROTATE_DURATION_MS = 200;
     private static final boolean HONEYCOMB_AND_ABOVE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
+
 
     public TextView mNumberTextView;
     public TextView mDataTextView;
@@ -35,6 +42,20 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
         mNumberTextView = (TextView) itemView.findViewById(R.id.list_item_parent_horizontal_number_textView);
         mDataTextView = (TextView) itemView.findViewById(R.id.list_item_parent_horizontal_parent_textView);
         mArrowExpandImageView = (ImageView) itemView.findViewById(R.id.list_item_parent_horizontal_arrow_imageView);
+        mArrowExpandImageView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                toggleExpansion();
+            }
+        });
+
+        final Context context = itemView.getContext();
+        itemView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Toast.makeText(context, "This sample shows how to make a row only expand upon clicking our custom arrow view", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     public void bind(int parentNumber, String parentText) {
@@ -55,5 +76,26 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
         } else {
             mArrowExpandImageView.setRotation(INITIAL_POSITION);
         }
+    }
+
+    @Override
+    public void expansionToggled(boolean isExpanded) {
+        super.expansionToggled(isExpanded);
+        if (!HONEYCOMB_AND_ABOVE) {
+            return;
+        }
+
+        RotateAnimation rotateAnimation = new RotateAnimation(ROTATED_POSITION,
+                INITIAL_POSITION,
+                RotateAnimation.RELATIVE_TO_SELF, PIVOT_VALUE,
+                RotateAnimation.RELATIVE_TO_SELF, PIVOT_VALUE);
+        rotateAnimation.setDuration(DEFAULT_ROTATE_DURATION_MS);
+        rotateAnimation.setFillAfter(true);
+        mArrowExpandImageView.startAnimation(rotateAnimation);
+    }
+
+    @Override
+    public boolean shouldEntireRowExpand() {
+        return false;
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -1,5 +1,7 @@
 package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 
+import android.annotation.SuppressLint;
+import android.os.Build;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -14,6 +16,9 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
  * Must extend ParentViewHolder.
  */
 public class HorizontalParentViewHolder extends ParentViewHolder {
+    private static final float INITIAL_POSITION = 0.0f;
+    private static final float ROTATED_POSITION = 180f;
+    private static final boolean HONEYCOMB_AND_ABOVE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 
     public TextView mNumberTextView;
     public TextView mDataTextView;
@@ -35,5 +40,20 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
     public void bind(int parentNumber, String parentText) {
         mNumberTextView.setText(String.valueOf(parentNumber));
         mDataTextView.setText(parentText);
+    }
+
+    @SuppressLint("NewApi")
+    @Override
+    public void setExpanded(boolean isExpanded) {
+        super.setExpanded(isExpanded);
+        if (!HONEYCOMB_AND_ABOVE) {
+            return;
+        }
+
+        if (isExpanded) {
+            mArrowExpandImageView.setRotation(ROTATED_POSITION);
+        } else {
+            mArrowExpandImageView.setRotation(INITIAL_POSITION);
+        }
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -79,8 +79,8 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
     }
 
     @Override
-    public void expansionToggled(boolean isExpanded) {
-        super.expansionToggled(isExpanded);
+    public void onExpansionToggled(boolean isExpanded) {
+        super.onExpansionToggled(isExpanded);
         if (!HONEYCOMB_AND_ABOVE) {
             return;
         }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -95,7 +95,7 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
     }
 
     @Override
-    public boolean shouldEntireRowExpand() {
+    public boolean shouldItemViewClickToggleExpansion() {
         return false;
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
@@ -9,14 +9,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.Spinner;
 import android.widget.Toast;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
 import com.bignerdranch.expandablerecyclerview.ClickListeners.ExpandCollapseListener;
 import com.bignerdranch.expandablerecyclerview.Model.ParentObject;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
@@ -33,17 +27,12 @@ import java.util.ArrayList;
  */
 public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity implements ExpandCollapseListener{
 
-    private static final long INITIAL_ROTATION_SPEED_MS = 100;
-    private static final int NUM_ANIMATION_DURATIONS = 10;
     private static final int NUM_TEST_DATA_ITEMS = 20;
 
     private VerticalExpandableAdapter mExpandableAdapter;
-    private ArrayList<Long> mDurationList;
 
     private Toolbar mToolbar;
     private RecyclerView mRecyclerView;
-    private CheckBox mAnimationEnabledCheckBox;
-    private Spinner mToolbarSpinner;
 
     public static Intent newIntent(Context context) {
         return new Intent(context, VerticalLinearRecyclerViewSampleActivity.class);
@@ -59,15 +48,6 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
 
         mRecyclerView = (RecyclerView) findViewById(R.id.activity_vertical_linear_recycler_view_sample_recyclerView);
 
-        mAnimationEnabledCheckBox = (CheckBox) findViewById(R.id.toolbar_sample_checkBox);
-        mAnimationEnabledCheckBox.setOnCheckedChangeListener(mAnimationEnabledCheckedChangeListener);
-
-        mToolbarSpinner = (Spinner) findViewById(R.id.toolbar_sample_spinner);
-        mToolbarSpinner.setOnItemSelectedListener(mToolbarSpinnerItemSelectListener);
-
-        // Generate spinner's list of rotation speeds (in ms)
-        mDurationList = generateSpinnerSpeeds();
-
         // Create a new adapter with 20 test data items
         mExpandableAdapter = new VerticalExpandableAdapter(this, setUpTestData(NUM_TEST_DATA_ITEMS));
 
@@ -78,10 +58,6 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
         mRecyclerView.setAdapter(mExpandableAdapter);
         // Set the layout manager to a LinearLayout manager for vertical list
         mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
-
-        // Set spinner adapter
-        VerticalSpinnerAdapter verticalSpinnerAdapter = new VerticalSpinnerAdapter(this, mDurationList);
-        mToolbarSpinner.setAdapter(verticalSpinnerAdapter);
     }
 
     /**
@@ -116,84 +92,13 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
         Toast.makeText(this, toastMessage, Toast.LENGTH_SHORT).show();
     }
 
-    private CompoundButton.OnCheckedChangeListener mAnimationEnabledCheckedChangeListener = new CompoundButton.OnCheckedChangeListener() {
-        @Override
-        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-            if (isChecked) { // Only the custom triggering view can trigger expansion
-                mExpandableAdapter.setParentAndIconExpandOnClick(false);
-            } else { // Both the custom triggering view and the parent item can trigger expansion
-                mExpandableAdapter.setParentAndIconExpandOnClick(true);
-            }
-
-            mExpandableAdapter.setCustomParentAnimationViewId(R.id.list_item_parent_horizontal_arrow_imageView);
-            mExpandableAdapter.setParentClickableViewAnimationDuration((Long) mToolbarSpinner.getSelectedItem());
-            mExpandableAdapter.notifyDataSetChanged();
-        }
-    };
-
-    private AdapterView.OnItemSelectedListener mToolbarSpinnerItemSelectListener = new AdapterView.OnItemSelectedListener() {
-        @Override
-        public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-            if (mAnimationEnabledCheckBox.isChecked()) {
-                enableCustomExpandButton(position);
-            } else {
-                disableCustomExpandButton(position);
-            }
-
-            mExpandableAdapter.notifyDataSetChanged();
-        }
-
-        @Override
-        public void onNothingSelected(AdapterView<?> parent) {
-            // Do nothing
-        }
-    };
-
     private void setupToolbar() {
         setSupportActionBar(mToolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
     }
-
-    /**
-     * Only the custom triggering view triggers expansion
-     */
-    private void enableCustomExpandButton(int animationDurationPosition) {
-        if (mDurationList.get(animationDurationPosition) == 0) {
-            // Sets the rotation animation to off
-            mExpandableAdapter.setParentClickableViewAnimationDuration(
-                    ExpandableRecyclerAdapter.CUSTOM_ANIMATION_DURATION_NOT_SET);
-        } else {
-            // Sets the animation duration to the corresponding duration at the selected position
-            mExpandableAdapter.setParentClickableViewAnimationDuration(mDurationList.get(animationDurationPosition));
-        }
-        // Disables clicking of both the item and the custom clickable view declared by the user
-        mExpandableAdapter.setParentAndIconExpandOnClick(false);
-    }
-
-    /**
-     * Both the custom triggering view and the parent item trigger expansion when clicked
-     */
-    private void disableCustomExpandButton(int position) {
-        if (mDurationList.get(position) == 0) {
-            // Sets the rotation animation to off
-            mExpandableAdapter.setParentClickableViewAnimationDuration(
-                    ExpandableRecyclerAdapter.CUSTOM_ANIMATION_DURATION_NOT_SET);
-            // Disable clicking of both parent and child to trigger expansion/collapsing
-            mExpandableAdapter.setParentAndIconExpandOnClick(false);
-        } else {
-            // Sets the animation duration to the corresponding duration at the selected position
-            mExpandableAdapter.setParentClickableViewAnimationDuration(mDurationList.get(position));
-            // Sets the custom triggering view to the id of the view
-            mExpandableAdapter.setCustomParentAnimationViewId(R.id.list_item_parent_horizontal_arrow_imageView);
-            // Sets both the custom triggering view and the parent item to trigger expansion
-            mExpandableAdapter.setParentAndIconExpandOnClick(true);
-        }
-    }
-
 
     /**
      * Method to set up test data used in the RecyclerView.
@@ -232,21 +137,5 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
             parentObjectList.add(verticalParentObject);
         }
         return parentObjectList;
-    }
-
-    /**
-     * Method to set up the list of animation durations for the Toolbar's Spinner.
-     * <p/>
-     * The list contains long values that correspond to the length of time (in ms) of the animation.
-     *
-     * @return the list of times (in ms) to be populated into the Toolbar's spinner.
-     */
-    private ArrayList<Long> generateSpinnerSpeeds() {
-        ArrayList<Long> speedList = new ArrayList<>();
-        speedList.add(ExpandableRecyclerAdapter.CUSTOM_ANIMATION_DURATION_NOT_SET);
-        for (int i = 1; i <= NUM_ANIMATION_DURATIONS; i++) {
-            speedList.add(INITIAL_ROTATION_SPEED_MS * i);
-        }
-        return speedList;
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParentViewHolder.java
@@ -1,6 +1,9 @@
 package com.ryanbrooks.expandablerecyclerviewsample.linear.vertical;
 
+import android.annotation.SuppressLint;
+import android.os.Build;
 import android.view.View;
+import android.view.animation.RotateAnimation;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -19,6 +22,12 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
  * @since 5/27/2015
  */
 public class VerticalParentViewHolder extends ParentViewHolder {
+    private static final float INITIAL_POSITION = 0.0f;
+    private static final float ROTATED_POSITION = 180f;
+    private static final float PIVOT_VALUE = 0.5f;
+    private static final long DEFAULT_ROTATE_DURATION_MS = 200;
+    private static final boolean HONEYCOMB_AND_ABOVE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
+
 
     public TextView mNumberTextView;
     public TextView mDataTextView;
@@ -40,5 +49,36 @@ public class VerticalParentViewHolder extends ParentViewHolder {
     public void bind(int parentNumber, String parentText) {
         mNumberTextView.setText(String.valueOf(parentNumber));
         mDataTextView.setText(parentText);
+    }
+
+    @SuppressLint("NewApi")
+    @Override
+    public void setExpanded(boolean isExpanded) {
+        super.setExpanded(isExpanded);
+        if (!HONEYCOMB_AND_ABOVE) {
+            return;
+        }
+
+        if (isExpanded) {
+            mArrowExpandImageView.setRotation(ROTATED_POSITION);
+        } else {
+            mArrowExpandImageView.setRotation(INITIAL_POSITION);
+        }
+    }
+
+    @Override
+    public void expansionToggled(boolean isExpanded) {
+        super.expansionToggled(isExpanded);
+        if (!HONEYCOMB_AND_ABOVE) {
+            return;
+        }
+
+        RotateAnimation rotateAnimation = new RotateAnimation(ROTATED_POSITION,
+                INITIAL_POSITION,
+                RotateAnimation.RELATIVE_TO_SELF, PIVOT_VALUE,
+                RotateAnimation.RELATIVE_TO_SELF, PIVOT_VALUE);
+        rotateAnimation.setDuration(DEFAULT_ROTATE_DURATION_MS);
+        rotateAnimation.setFillAfter(true);
+        mArrowExpandImageView.startAnimation(rotateAnimation);
     }
 }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParentViewHolder.java
@@ -67,8 +67,8 @@ public class VerticalParentViewHolder extends ParentViewHolder {
     }
 
     @Override
-    public void expansionToggled(boolean isExpanded) {
-        super.expansionToggled(isExpanded);
+    public void onExpansionToggled(boolean isExpanded) {
+        super.onExpansionToggled(isExpanded);
         if (!HONEYCOMB_AND_ABOVE) {
             return;
         }

--- a/app/src/main/res/layout/toolbar_sample.xml
+++ b/app/src/main/res/layout/toolbar_sample.xml
@@ -4,5 +4,4 @@
     android:id="@+id/activity_vertical_linear_recycler_view_sample_toolbar"
     android:layout_height="?attr/actionBarSize"
     android:layout_width="match_parent"
-    android:background="@color/primary_green">
-</android.support.v7.widget.Toolbar>
+    android:background="@color/primary_green" />

--- a/app/src/main/res/layout/toolbar_sample.xml
+++ b/app/src/main/res/layout/toolbar_sample.xml
@@ -5,18 +5,4 @@
     android:layout_height="?attr/actionBarSize"
     android:layout_width="match_parent"
     android:background="@color/primary_green">
-
-    <CheckBox
-        android:id="@+id/toolbar_sample_checkBox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/white"
-        android:text="@string/toolbar_sample_checkBox"/>
-
-    <Spinner
-        android:id="@+id/toolbar_sample_spinner"
-        android:layout_gravity="end"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
 </android.support.v7.widget.Toolbar>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="coming_soon">Feature coming soon</string>
 
     <!-- Linear sample -->
+    <string name="activity_vertical_linear_sample_title">Vertical Linear Sample</string>
+    <string name="activity_horizontal_linear_sample_title">Horizontal Linear Sample</string>
     <string name="toolbar_sample_checkBox">Custom Expand Button</string>
     <string name="child_text">Child %1$d</string>
     <string name="second_child_text">Child %1$d_2</string>

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
@@ -26,9 +26,6 @@ public class CrimeListFragment extends Fragment {
         mCrimeRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
 
         CrimeExpandableAdapter crimeExpandableAdapter = new CrimeExpandableAdapter(getActivity(), generateCrimes());
-        crimeExpandableAdapter.setCustomParentAnimationViewId(R.id.parent_list_item_expand_arrow);
-        crimeExpandableAdapter.setParentClickableViewAnimationDefaultDuration();
-        crimeExpandableAdapter.setParentAndIconExpandOnClick(true);
         crimeExpandableAdapter.onRestoreInstanceState(savedInstanceState);
 
         mCrimeRecyclerView.setAdapter(crimeExpandableAdapter);

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeParentViewHolder.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeParentViewHolder.java
@@ -1,15 +1,17 @@
 package com.bignerdranch.android.criminalintent;
 
+import android.annotation.SuppressLint;
+import android.os.Build;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
 import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
 
-/**
- * Created by ryanbrooks on 6/17/15.
- */
 public class CrimeParentViewHolder extends ParentViewHolder {
+    private static final float INITIAL_POSITION = 0.0f;
+    private static final float ROTATED_POSITION = 180f;
+    private static final boolean HONEYCOMB_AND_ABOVE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 
     public TextView mCrimeTitleTextView;
     public ImageButton mParentDropDownArrow;
@@ -19,5 +21,20 @@ public class CrimeParentViewHolder extends ParentViewHolder {
 
         mCrimeTitleTextView = (TextView) itemView.findViewById(R.id.parent_list_item_crime_title_text_view);
         mParentDropDownArrow = (ImageButton) itemView.findViewById(R.id.parent_list_item_expand_arrow);
+    }
+
+    @SuppressLint("NewApi")
+    @Override
+    public void setExpanded(boolean isExpanded) {
+        super.setExpanded(isExpanded);
+        if (!HONEYCOMB_AND_ABOVE) {
+            return;
+        }
+
+        if (isExpanded) {
+            mParentDropDownArrow.setRotation(ROTATED_POSITION);
+        } else {
+            mParentDropDownArrow.setRotation(INITIAL_POSITION);
+        }
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -2,7 +2,6 @@ package com.bignerdranch.expandablerecyclerview.Adapter;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
@@ -32,18 +31,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     private static final String STABLE_ID_MAP = "ExpandableRecyclerAdapter.StableIdMap";
     private static final int TYPE_PARENT = 0;
     private static final int TYPE_CHILD = 1;
-    public static final int CUSTOM_ANIMATION_VIEW_NOT_SET = -1;
-    public static final long DEFAULT_ROTATE_DURATION_MS = 200l;
-    public static final long CUSTOM_ANIMATION_DURATION_NOT_SET = -1l;
 
     protected Context mContext;
     protected List<? extends ParentObject> mParentItemList;
     private List<Object> mHelperItemList;
     private HashMap<Long, Boolean> mStableIdMap;
     private ExpandCollapseListener mExpandCollapseListener;
-    private boolean mParentAndIconClickable = false;
-    private int mCustomParentAnimationViewId = CUSTOM_ANIMATION_VIEW_NOT_SET;
-    private long mAnimationDuration = CUSTOM_ANIMATION_DURATION_NOT_SET;
 
     /**
      * Public constructor for the base ExpandableRecyclerView. This constructor takes in no
@@ -54,41 +47,11 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * @param parentItemList
      */
     public ExpandableRecyclerAdapter(Context context, @NonNull List<? extends ParentObject> parentItemList) {
-        this(context, parentItemList, CUSTOM_ANIMATION_VIEW_NOT_SET, CUSTOM_ANIMATION_DURATION_NOT_SET);
-    }
-
-    /**
-     * Public constructor for a more robust ExpandableRecyclerView. This constructor takes in an
-     * id for a custom clickable view that will trigger the expansion or collapsing of the child.
-     * By default, a parent item click is the trigger for the expanding/collapsing.
-     *
-     * @param context
-     * @param parentItemList
-     * @param customParentAnimationViewId
-     */
-    public ExpandableRecyclerAdapter(Context context, @NonNull List<? extends ParentObject> parentItemList,
-                                     @IdRes int customParentAnimationViewId) {
-        this(context, parentItemList, customParentAnimationViewId, CUSTOM_ANIMATION_DURATION_NOT_SET);
-    }
-
-    /**
-     * Public constructor for even more robust ExpandableRecyclerView. This constructor takes in
-     * both an id for a custom clickable view that will trigger the expansion or collapsing of the
-     * child along with a long for a custom duration in MS for the rotation animation.
-     *
-     * @param context
-     * @param parentItemList
-     * @param customParentAnimationViewId
-     * @param animationDuration
-     */
-    public ExpandableRecyclerAdapter(Context context, @NonNull List<? extends ParentObject> parentItemList,
-                                     @IdRes int customParentAnimationViewId, long animationDuration) {
+        super();
         mContext = context;
         mParentItemList = parentItemList;
         mHelperItemList = ExpandableRecyclerAdapterHelper.generateHelperItemList(parentItemList);
         mStableIdMap = generateStableIdMapFromList(mHelperItemList);
-        mCustomParentAnimationViewId = customParentAnimationViewId;
-        mAnimationDuration = animationDuration;
     }
 
     /**
@@ -135,16 +98,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         if (helperItem instanceof ParentWrapper) {
             PVH parentViewHolder = (PVH) holder;
 
-            parentViewHolder.cancelAnimation();
-
-            if (hasCustomAnimationView() && hasAnimationDuration()) {
-                parentViewHolder.setCustomClickableView(mCustomParentAnimationViewId, mParentAndIconClickable);
-                parentViewHolder.setAnimationDuration(mAnimationDuration);
-            } else if (hasCustomAnimationView()) {
-                parentViewHolder.setCustomClickableView(mCustomParentAnimationViewId, mParentAndIconClickable);
-            } else {
-                parentViewHolder.setMainItemClickToExpand();
-            }
+            parentViewHolder.setMainItemClickToExpand();
 
             ParentWrapper parentWrapper = (ParentWrapper) helperItem;
             parentViewHolder.setExpanded(parentWrapper.isExpanded());
@@ -232,51 +186,6 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             ParentObject parentObject = ((ParentWrapper) helperItem).getParentObject();
             expandParent(parentObject, position);
         }
-    }
-
-    /**
-     * Setter for the Default rotation duration (200 MS)
-     */
-    public void setParentClickableViewAnimationDefaultDuration() {
-        mAnimationDuration = DEFAULT_ROTATE_DURATION_MS;
-    }
-
-    /**
-     * Setter for a custom rotation animation duration in MS
-     *
-     * @param animationDuration in MS
-     */
-    public void setParentClickableViewAnimationDuration(long animationDuration) {
-        mAnimationDuration = animationDuration;
-    }
-
-    /**
-     * Setter for a custom clickable view to expand or collapse the item. This should be passed
-     * as a reference to the View's R.id
-     *
-     * @param customParentAnimationViewId
-     */
-    public void setCustomParentAnimationViewId(@IdRes int customParentAnimationViewId) {
-        mCustomParentAnimationViewId = customParentAnimationViewId;
-    }
-
-    /**
-     * Set the ability to be able to click both the whole parent view and the custom button to trigger
-     * expanding and collapsing
-     *
-     * @param parentAndIconClickable
-     */
-    public void setParentAndIconExpandOnClick(boolean parentAndIconClickable) {
-        mParentAndIconClickable = parentAndIconClickable;
-    }
-
-    /**
-     * Call this when removing the animation. This will set the parent item to be the expand/collapse
-     * trigger. It will also disable the rotation animation.
-     */
-    public void removeAnimation() {
-        mCustomParentAnimationViewId = CUSTOM_ANIMATION_VIEW_NOT_SET;
-        mAnimationDuration = CUSTOM_ANIMATION_DURATION_NOT_SET;
     }
 
     public void addExpandCollapseListener(ExpandCollapseListener expandCollapseListener) {
@@ -433,13 +342,5 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
     private Object getHelperItem(int position) {
         return mHelperItemList.get(position);
-    }
-
-    private boolean hasCustomAnimationView() {
-        return mCustomParentAnimationViewId != CUSTOM_ANIMATION_VIEW_NOT_SET;
-    }
-
-    private boolean hasAnimationDuration() {
-        return mAnimationDuration != CUSTOM_ANIMATION_DURATION_NOT_SET;
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -98,7 +98,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         if (helperItem instanceof ParentWrapper) {
             PVH parentViewHolder = (PVH) holder;
 
-            parentViewHolder.setMainItemClickToExpand();
+            if (parentViewHolder.shouldEntireRowExpand()) {
+                parentViewHolder.setMainItemClickToExpand();
+            }
 
             ParentWrapper parentWrapper = (ParentWrapper) helperItem;
             parentViewHolder.setExpanded(parentWrapper.isExpanded());

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -95,7 +95,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         if (helperItem instanceof ParentWrapper) {
             PVH parentViewHolder = (PVH) holder;
 
-            if (parentViewHolder.shouldEntireRowExpand()) {
+            if (parentViewHolder.shouldItemViewClickToggleExpansion()) {
                 parentViewHolder.setMainItemClickToExpand();
             }
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -39,12 +39,10 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     private ExpandCollapseListener mExpandCollapseListener;
 
     /**
-     * Public constructor for the base ExpandableRecyclerView. This constructor takes in no
-     * extra parameters for custom clickable views and animation durations. This means a click of
-     * the parent item will trigger the expansion.
+     * Public constructor for the base ExpandableRecyclerView.
      *
      * @param context
-     * @param parentItemList
+     * @param parentItemList List of all parent objects that make up the recyclerview
      */
     public ExpandableRecyclerAdapter(Context context, @NonNull List<? extends ParentObject> parentItemList) {
         super();
@@ -63,7 +61,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      *
      * @param viewGroup
      * @param viewType
-     * @return the ViewHolder that cooresponds to the item at the position.
+     * @return the ViewHolder that corresponds to the item at the position.
      */
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
@@ -85,8 +83,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * ChildViewHolder. The respective onBindViewHolders for ParentObjects and ChildObject are then
      * called.
      *
-     * If the item is a ParentObject, setting the ParentViewHolder's animation settings are then handled
-     * here.
+     * If the item is a ParentObject, sets the entire row to trigger expansion if instructed to
      *
      * @param holder
      * @param position

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -83,7 +83,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
 
     /**
      * Implementation of View.onClick to listen for the clicks on the entire row.
-     * Only registered if {@link #shouldEntireRowExpand()} is true
+     * Only registered if {@link #shouldItemViewClickToggleExpansion()} is true
      *
      * @param v the view that is the trigger for expansion
      */
@@ -98,7 +98,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * a click in your custom view.
      * @return true to set a click listener on the item view that toggle expansion
      */
-    public boolean shouldEntireRowExpand() {
+    public boolean shouldItemViewClickToggleExpansion() {
         return true;
     }
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -46,7 +46,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
 
     /**
      * Setter method for expanded state, used for initialization of expanded state.
-     * changes to the state are given in {@link #expansionToggled(boolean)}
+     * changes to the state are given in {@link #onExpansionToggled(boolean)}
      *
      * @param isExpanded
      */
@@ -59,7 +59,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * Useful for implementing parent view animations for expansion
      * @param isExpanded
      */
-    protected void expansionToggled(boolean isExpanded) {
+    protected void onExpansionToggled(boolean isExpanded) {
 
     }
 
@@ -108,7 +108,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     protected void toggleExpansion() {
         if (mParentItemClickListener != null) {
             setExpanded(!mIsExpanded);
-            expansionToggled(mIsExpanded);
+            onExpansionToggled(mIsExpanded);
             mParentItemClickListener.onParentItemClickListener(getLayoutPosition());
         }
     }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -1,10 +1,7 @@
 package com.bignerdranch.expandablerecyclerview.ViewHolder;
 
-import android.os.Build;
-import android.support.annotation.IdRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import android.view.animation.RotateAnimation;
 
 import com.bignerdranch.expandablerecyclerview.ClickListeners.ParentItemClickListener;
 
@@ -18,20 +15,9 @@ import com.bignerdranch.expandablerecyclerview.ClickListeners.ParentItemClickLis
  * @since 5/27/2015
  */
 public class ParentViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
-    private final String TAG = getClass().getSimpleName();
-
-    private static final float INITIAL_POSITION = 0.0f;
-    private static final float ROTATED_POSITION = 180f;
-    private static final float PIVOT_VALUE = 0.5f;
-    private static final long DEFAULT_ROTATE_DURATION_MS = 200;
-    private static final boolean HONEYCOMB_AND_ABOVE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 
     private ParentItemClickListener mParentItemClickListener;
-    private View mClickableView;
-    private boolean mRotationEnabled;
     private boolean mIsExpanded;
-    private long mDuration;
-    private float mRotation;
 
     /**
      * Public constructor that takes in an ItemView along with an implementation of
@@ -43,51 +29,6 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     public ParentViewHolder(View itemView) {
         super(itemView);
         mIsExpanded = false;
-        mDuration = DEFAULT_ROTATE_DURATION_MS;
-        mRotation = INITIAL_POSITION;
-    }
-
-    /**
-     * Setter for a custom Clickable view. The user should pass in the id of the view that they
-     * wish to be the expansion trigger.
-     *
-     * @param clickableViewId id of view which should be clickable
-     * @param itemViewClickable whether the entire itemView is clickable as well.
-     */
-    public void setCustomClickableView(@IdRes int clickableViewId, boolean itemViewClickable) {
-        mClickableView = itemView.findViewById(clickableViewId);
-        mClickableView.setOnClickListener(this);
-        if (itemViewClickable) {
-            itemView.setOnClickListener(this);
-        } else {
-            itemView.setOnClickListener(null);
-        }
-        if (HONEYCOMB_AND_ABOVE && mRotationEnabled) {
-            mClickableView.setRotation(mRotation);
-        }
-    }
-
-    /**
-     * Setter method for a user defined Animation duration (in MS)
-     *
-     * @param animationDuration
-     */
-    public void setAnimationDuration(long animationDuration) {
-        mRotationEnabled = true;
-        mDuration = animationDuration;
-        if (HONEYCOMB_AND_ABOVE && mRotationEnabled) {
-            mClickableView.setRotation(mRotation);
-        }
-    }
-
-    /**
-     * Disables animation of the custom clickable button.
-     */
-    public void cancelAnimation() {
-        mRotationEnabled = false;
-        if (HONEYCOMB_AND_ABOVE && mRotationEnabled) {
-            mClickableView.setRotation(mRotation);
-        }
     }
 
     /**
@@ -95,11 +36,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * clickable view.
      */
     public void setMainItemClickToExpand() {
-        if (mClickableView != null) {
-            mClickableView.setOnClickListener(null);
-        }
         itemView.setOnClickListener(this);
-        mRotationEnabled = false;
     }
 
     /**
@@ -112,37 +49,22 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
-     * Setter method for the item to be expanded or not. Also triggers the animation of the custom
-     * clickable view if it and the rotation duration are both defined.
+     * Setter method for expanded state, used for initialization of expanded state.
+     * changes to the state are given in {@link #expansionToggled(boolean)}
      *
      * @param isExpanded
      */
     public void setExpanded(boolean isExpanded) {
         mIsExpanded = isExpanded;
-        if (mRotationEnabled) {
-            if (mIsExpanded && mClickableView != null && HONEYCOMB_AND_ABOVE) {
-                mClickableView.setRotation(ROTATED_POSITION);
-            } else if (mClickableView != null && HONEYCOMB_AND_ABOVE) {
-                mClickableView.setRotation(INITIAL_POSITION);
-            }
-        }
     }
 
     /**
-     * @return true if rotation is enabled, false if not
+     * Called when expansion is changed, does not get called during the initial binding
+     * Useful for implementing parent view animations for expansion
+     * @param isExpanded
      */
-    public boolean isRotationEnabled() {
-        return mRotationEnabled;
-    }
+    protected void expansionToggled(boolean isExpanded) {
 
-    /**
-     * Sets the position of the custom clickable view. 0f is default and 180f is roatated
-     *
-     * @param rotation
-     */
-    public void setRotation(float rotation) {
-        mRotationEnabled = true;
-        mRotation = rotation;
     }
 
     /**
@@ -171,20 +93,16 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      */
     @Override
     public void onClick(View v) {
+        toggleExpansion();
+    }
+
+    /**
+     * Triggers expansion for the parent row
+     */
+    protected void toggleExpansion() {
         if (mParentItemClickListener != null) {
-            if (mClickableView != null) {
-                if (mRotationEnabled) {
-                    RotateAnimation rotateAnimation = new RotateAnimation(ROTATED_POSITION,
-                            INITIAL_POSITION,
-                            RotateAnimation.RELATIVE_TO_SELF, PIVOT_VALUE,
-                            RotateAnimation.RELATIVE_TO_SELF, PIVOT_VALUE);
-                    mRotation = INITIAL_POSITION;
-                    rotateAnimation.setDuration(mDuration);
-                    rotateAnimation.setFillAfter(true);
-                    mClickableView.startAnimation(rotateAnimation);
-                }
-            }
             setExpanded(!mIsExpanded);
+            expansionToggled(mIsExpanded);
             mParentItemClickListener.onParentItemClickListener(getLayoutPosition());
         }
     }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -97,6 +97,16 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
+     * Used to determine whether the entire row should trigger row expansion,
+     * if you return false, call {@link #toggleExpansion()} to toggle an expansion in response to
+     * a click in your custom view.
+     * @return true to set a click listener on the item view that toggle expansion
+     */
+    public boolean shouldEntireRowExpand() {
+        return true;
+    }
+
+    /**
      * Triggers expansion for the parent row
      */
     protected void toggleExpansion() {

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -7,8 +7,8 @@ import com.bignerdranch.expandablerecyclerview.ClickListeners.ParentItemClickLis
 
 
 /**
- * ParentViewHolder that extends the Base RecyclerView ViewHolder. All expansion animation and click
- * handling is done here.
+ * ParentViewHolder that extends the Base RecyclerView ViewHolder. Keeps track of expansion and
+ * offers the ability to animate in response to a triggered expansion
  *
  * @author Ryan Brooks
  * @version 1.0
@@ -20,11 +20,8 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     private boolean mIsExpanded;
 
     /**
-     * Public constructor that takes in an ItemView along with an implementation of
-     * ParentItemClickListener to handle the clicks of either the Parent item or the custom defined
-     * view.
-     *
-     * @param itemView
+     * Default constructor
+     * @param itemView view that will be shown for this ViewHolder
      */
     public ParentViewHolder(View itemView) {
         super(itemView);
@@ -32,8 +29,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
-     * Sets the Parent only as the trigger to expand the item. Also disables rotation of the custom
-     * clickable view.
+     * Sets the Parent only as the trigger to expand the item.
      */
     public void setMainItemClickToExpand() {
         itemView.setOnClickListener(this);
@@ -86,8 +82,8 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
-     * Implementation of View.onClick to listen for the clicks on either the Parent item or the
-     * custom clickable view if applicable. Triggers rotation if enabled on click.
+     * Implementation of View.onClick to listen for the clicks on the entire row.
+     * Only registered if {@link #shouldEntireRowExpand()} is true
      *
      * @param v the view that is the trigger for expansion
      */


### PR DESCRIPTION
Code for rotating a view was complicating the library unnecessarily which brought up discussion to pull it out since the equivalent functionality can be achieved within the users implentation of the ParentViewHolder. 

An example of this is shown within `VerticalParentViewHolder`