### PR TITLE
Removal of "stable id"

### DIFF
--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -11,14 +11,11 @@ import java.util.List;
  */
 public class ExpandableRecyclerAdapterHelper {
 
-    private static int sCurrentId;
-
     public static List<Object> generateHelperItemList(List<? extends ParentObject> itemList) {
         ArrayList<Object> parentWrapperList = new ArrayList<>();
         for (int i = 0; i < itemList.size(); i++) {
             ParentObject parentObject = itemList.get(i);
-            ParentWrapper parentWrapper = new ParentWrapper(parentObject, sCurrentId);
-            sCurrentId++;
+            ParentWrapper parentWrapper = new ParentWrapper(parentObject);
             parentWrapperList.add(parentWrapper);
             if (parentObject.isInitiallyExpanded()) {
                 parentWrapper.setExpanded(true);
@@ -27,7 +24,6 @@ public class ExpandableRecyclerAdapterHelper {
                 }
             }
         }
-        sCurrentId = 0;
         return parentWrapperList;
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentObject.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentObject.java
@@ -4,16 +4,6 @@ import java.util.List;
 
 /**
  * Interface for implementing required methods in a ParentObject
- *
- * In the user's specified ParentObject, they should set instance variables for the following:
- *
- * boolean mExpanded: for the Parent's current expanded state
- * Object (or the user's custom ChildObject type) mChildObject: the reference to the Parent's ChildObject
- * long mStableId: A unique long to properly identify the ParentObject from other ParentObjects
- *
- * @author Ryan Brooks
- * @version 1.0
- * @since 5/27/2015
  */
 public interface ParentObject {
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -5,12 +5,10 @@ package com.bignerdranch.expandablerecyclerview.Model;
  */
 public class ParentWrapper {
     private boolean mIsExpanded;
-    private long mStableId;
     private ParentObject mParentObject;
 
-    public ParentWrapper(ParentObject parentObject, int stableId) {
+    public ParentWrapper(ParentObject parentObject) {
         mParentObject = parentObject;
-        mStableId = stableId;
         mIsExpanded = false;
     }
 
@@ -28,13 +26,5 @@ public class ParentWrapper {
 
     public void setExpanded(boolean isExpanded) {
         mIsExpanded = isExpanded;
-    }
-
-    public long getStableId() {
-        return mStableId;
-    }
-
-    public void setStableId(long stableId) {
-        mStableId = stableId;
     }
 }


### PR DESCRIPTION
We relied on an idea of a stable id for storing the expanded state and then restoring it on rotation. This id was not stable and relied on the position within the array of parent objects. 

In order to avoid confusion for future development I've pulled it out and simplified the restore/save code to use position as a save point and restore based on that. 

Added some information to the comments to reflect this change (though there is no change in behavior, just making the user more aware).