### PR TITLE
Javadoc cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: android
-jdk: oraclejdk8
+jdk: oraclejdk7
 script: ./gradlew clean build
 
 android:

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/MainActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/MainActivity.java
@@ -1,6 +1,5 @@
 package com.ryanbrooks.expandablerecyclerviewsample;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -13,7 +12,6 @@ import com.ryanbrooks.expandablerecyclerviewsample.linear.vertical.VerticalLinea
 
 /**
  * Main Activity that contains navigation for sample application.
- * Uses ButterKnife to inject view resources.
  *
  * @author Ryan Brooks
  * @version 1.0

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChild.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChild.java
@@ -1,8 +1,10 @@
 package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 
 /**
- * Custom child object. This is for demo purposes, although it is recommended having a separate
- * child object from your parent object.
+ * Custom child list item.
+ *
+ * This is for demo purposes, although it is recommended having a separate
+ * child from your parent.
  */
 public class HorizontalChild {
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChildViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChildViewHolder.java
@@ -8,7 +8,7 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 /**
  * Custom child ViewHolder. Any views should be found and set to public variables here to be
- * referenced in your custom ExpandableAdapter later.
+ * referenced in your custom ExpandableRecyclerAdapter later.
  *
  * Must extend ChildViewHolder.
  */

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalExpandableAdapter.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalExpandableAdapter.java
@@ -62,7 +62,7 @@ public class HorizontalExpandableAdapter extends ExpandableRecyclerAdapter<Horiz
      * @param position the position in the RecyclerView of the item
      */
     @Override
-    public void onBindParentViewHolder(HorizontalParentViewHolder parentViewHolder, int position, Object parentListItem) {
+    public void onBindParentViewHolder(HorizontalParentViewHolder parentViewHolder, int position, ParentListItem parentListItem) {
         HorizontalParentListItem horizontalParentListItem = (HorizontalParentListItem) parentListItem;
         parentViewHolder.bind(horizontalParentListItem.getParentNumber(), horizontalParentListItem.getParentText());
     }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -145,14 +145,14 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
 
     /**
      * Method to set up test data used in the RecyclerView.
-     * <p/>
-     * Each child object contains a string.
-     * Each parent object contains a number corresponding to the number of the parent and a string
+     *
+     * Each child list item contains a string.
+     * Each parent list item contains a number corresponding to the number of the parent and a string
      * that contains a message.
      * Each parent also contains a list of children which is generated in this. Every odd numbered
      * parent gets one child and every even numbered parent gets two children.
      *
-     * @return an ArrayList of Objects that contains all parent items. Expansion of children are handled in the adapter
+     * @return A List of Objects that contains all parent items. Expansion of children are handled in the adapter
      */
     private List<ParentListItem> setUpTestData(int numItems) {
         List<ParentListItem> parentListItemList = new ArrayList<>();

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParent.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParent.java
@@ -6,8 +6,8 @@ import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import java.util.List;
 
 /**
- * Custom parent object that holds a string and an int for displaying data in the parent item. You
- * can use any Object here as long as it implements ParentObject and sets the list to a private
+ * Custom parent list item that holds a string and an int for displaying data in the parent item. You
+ * can use any Object here as long as it implements ParentListItem and sets the list to a private
  * variable.
  */
 public class HorizontalParent implements ParentListItem {
@@ -36,9 +36,9 @@ public class HorizontalParent implements ParentListItem {
     }
 
     /**
-     * Getter method for the list of children associated with this parent object
+     * Getter method for the list of children associated with this parent list item
      *
-     * @return list of all children associated with this specific parent object
+     * @return list of all children associated with this specific parent list item
      */
     @Override
     public List<Object> getChildItemList() {
@@ -46,9 +46,9 @@ public class HorizontalParent implements ParentListItem {
     }
 
     /**
-     * Setter method for the list of children associated with this parent object
+     * Setter method for the list of children associated with this parent list item
      *
-     * @param childItemList the list of all children associated with this parent object
+     * @param childItemList the list of all children associated with this parent list item
      */
     public void setChildItemList(List<Object> childItemList) {
         mChildItemList = childItemList;

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -16,7 +16,7 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
 /**
  * Custom parent ViewHolder. Any views should be found and set to public variables here to be
  * referenced in your custom ExpandableAdapter later.
- * <p>
+ *
  * Must extend ParentViewHolder.
  */
 public class HorizontalParentViewHolder extends ParentViewHolder {

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalChild.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalChild.java
@@ -1,8 +1,10 @@
 package com.ryanbrooks.expandablerecyclerviewsample.linear.vertical;
 
 /**
- * Custom child object. This is for demo purposes, although it is recommended having a separate
- * child object from your parent object.
+ * Custom child list item.
+ *
+ * This is for demo purposes, although it is recommended having a separate
+ * child list item from your parent list item.
  *
  * @author Ryan Brooks
  * @version 1.0

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalChildViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalChildViewHolder.java
@@ -10,7 +10,7 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
 /**
  * Custom child ViewHolder. Any views should be found and set to public variables here to be
  * referenced in your custom ExpandableAdapter later.
- * <p>
+ *
  * Must extend ChildViewHolder.
  *
  * @author Ryan Brooks

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalExpandableAdapter.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalExpandableAdapter.java
@@ -66,7 +66,7 @@ public class VerticalExpandableAdapter extends ExpandableRecyclerAdapter<Vertica
      * @param position the position in the RecyclerView of the item
      */
     @Override
-    public void onBindParentViewHolder(VerticalParentViewHolder parentViewHolder, int position, Object parentListItem) {
+    public void onBindParentViewHolder(VerticalParentViewHolder parentViewHolder, int position, ParentListItem parentListItem) {
         VerticalParentListItem verticalParentListItem = (VerticalParentListItem) parentListItem;
         parentViewHolder.bind(verticalParentListItem.getParentNumber(), verticalParentListItem.getParentText());
     }

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
@@ -103,14 +103,14 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
 
     /**
      * Method to set up test data used in the RecyclerView.
-     * <p/>
-     * Each child object contains a string.
-     * Each parent object contains a number corresponding to the number of the parent and a string
+     *
+     * Each child list item contains a string.
+     * Each parent list item contains a number corresponding to the number of the parent and a string
      * that contains a message.
      * Each parent also contains a list of children which is generated in this. Every odd numbered
      * parent gets one child and every even numbered parent gets two children.
      *
-     * @return an ArrayList of Objects that contains all parent items. Expansion of children are handled in the adapter
+     * @return A List of Objects that contains all parent items. Expansion of children are handled in the adapter
      */
     private List<ParentListItem> setUpTestData(int numItems) {
         List<ParentListItem> parentListItemList = new ArrayList<>();

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParent.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParent.java
@@ -6,8 +6,8 @@ import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import java.util.List;
 
 /**
- * Custom parent object that holds a string and an int for displaying data in the parent item. You
- * can use any Object here as long as it implements ParentObject and sets the list to a private
+ * Custom parent list item that holds a string and an int for displaying data in the parent item. You
+ * can use any Object here as long as it implements ParentListItem and sets the list to a private
  * variable.
  *
  * @author Ryan Brooks
@@ -39,9 +39,9 @@ public class VerticalParent implements ParentListItem {
     }
 
     /**
-     * Getter method for the list of children associated with this parent object
+     * Getter method for the list of children associated with this parent list item
      *
-     * @return list of all children associated with this specific parent object
+     * @return list of all children associated with this specific parent list item
      */
     @Override
     public List<Object> getChildItemList() {
@@ -49,9 +49,9 @@ public class VerticalParent implements ParentListItem {
     }
 
     /**
-     * Setter method for the list of children associated with this parent object
+     * Setter method for the list of children associated with this parent list item
      *
-     * @param childItemList the list of all children associated with this parent object
+     * @param childItemList the list of all children associated with this parent list item
      */
     public void setChildItemList(List<Object> childItemList) {
         mChildItemList = childItemList;

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParentViewHolder.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParentViewHolder.java
@@ -13,8 +13,8 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 /**
  * Custom parent ViewHolder. Any views should be found and set to public variables here to be
- * referenced in your custom ExpandableAdapter later.
- * <p>
+ * referenced in your custom ExpandableRecyclerAdapter later.
+ *
  * Must extend ParentViewHolder
  *
  * @author Ryan Brooks

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeChild.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeChild.java
@@ -5,12 +5,12 @@ import java.util.Date;
 /**
  * Created by ryanbrooks on 6/17/15.
  */
-public class CrimeChildListItem {
+public class CrimeChild {
 
     private Date mDate;
     private boolean mSolved;
 
-    public CrimeChildListItem(Date date, boolean solved) {
+    public CrimeChild(Date date, boolean solved) {
         mDate = date;
         mSolved = solved;
     }

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeExpandableAdapter.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeExpandableAdapter.java
@@ -33,14 +33,14 @@ public class CrimeExpandableAdapter extends ExpandableRecyclerAdapter<CrimeParen
     }
 
     @Override
-    public void onBindParentViewHolder(CrimeParentViewHolder crimeParentViewHolder, int i, Object o) {
-        Crime crime = (Crime) o;
+    public void onBindParentViewHolder(CrimeParentViewHolder crimeParentViewHolder, int i, ParentListItem parentListItem) {
+        Crime crime = (Crime) parentListItem;
         crimeParentViewHolder.mCrimeTitleTextView.setText(crime.getTitle());
     }
 
     @Override
-    public void onBindChildViewHolder(CrimeChildViewHolder crimeChildViewHolder, int i, Object o) {
-        CrimeChildListItem crimeChildListItem = (CrimeChildListItem) o;
+    public void onBindChildViewHolder(CrimeChildViewHolder crimeChildViewHolder, int i, Object childListItem) {
+        CrimeChildListItem crimeChildListItem = (CrimeChildListItem) childListItem;
         crimeChildViewHolder.mCrimeDateText.setText(crimeChildListItem.getDate().toString());
         crimeChildViewHolder.mCrimeSolvedCheckBox.setChecked(crimeChildListItem.isSolved());
     }

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeExpandableAdapter.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeExpandableAdapter.java
@@ -40,8 +40,8 @@ public class CrimeExpandableAdapter extends ExpandableRecyclerAdapter<CrimeParen
 
     @Override
     public void onBindChildViewHolder(CrimeChildViewHolder crimeChildViewHolder, int i, Object childListItem) {
-        CrimeChildListItem crimeChildListItem = (CrimeChildListItem) childListItem;
-        crimeChildViewHolder.mCrimeDateText.setText(crimeChildListItem.getDate().toString());
-        crimeChildViewHolder.mCrimeSolvedCheckBox.setChecked(crimeChildListItem.isSolved());
+        CrimeChild crimeChild = (CrimeChild) childListItem;
+        crimeChildViewHolder.mCrimeDateText.setText(crimeChild.getDate().toString());
+        crimeChildViewHolder.mCrimeSolvedCheckBox.setChecked(crimeChild.isSolved());
     }
 }

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
@@ -44,7 +44,7 @@ public class CrimeListFragment extends Fragment {
         List<ParentListItem> parentListItems = new ArrayList<>();
         for (Crime crime : crimes) {
             List<Object> childItemList = new ArrayList<>();
-            childItemList.add(new CrimeChildListItem(crime.getDate(), crime.isSolved()));
+            childItemList.add(new CrimeChild(crime.getDate(), crime.isSolved()));
             crime.setChildItemList(childItemList);
             parentListItems.add(crime);
         }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -94,8 +94,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * @param holder The {@link android.support.v7.widget.RecyclerView.ViewHolder}
      *               to bind data to
      * @param position The index in the list at which to bind
-     * @throws IllegalStateException if the item in the list is either {@value null}
-     *         or not of type {@link ParentListItem}
+     * @throws IllegalStateException if the item in the list is either null or
+     *         not of type {@link ParentListItem}
      */
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
@@ -142,7 +142,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     /**
      * Callback called from {@link #onBindViewHolder(RecyclerView.ViewHolder, int)}
      * when the list item bound to is a parent.
-     * <p/>
+     * <p>
      * Bind data to the {@link PVH} here.
      *
      * @param parentViewHolder The {@code PVH} to bind data to
@@ -155,7 +155,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     /**
      * Callback called from {@link #onBindViewHolder(RecyclerView.ViewHolder, int)}
      * when the list item bound to is a child.
-     * <p/>
+     * <p>
      * Bind data to the {@link CVH} here.
      *
      * @param childViewHolder The {@code CVH} to bind data to
@@ -343,11 +343,11 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
     /**
      * Stores the expanded state map across state loss.
-     * <p/>
+     * <p>
      * Should be called from {@link Activity#onSaveInstanceState(Bundle)} in
      * the {@link Activity} that hosts the {@link RecyclerView} that this
      * {@link ExpandableRecyclerAdapter} is attached to.
-     * <p/>
+     * <p>
      * This will make sure to add the expanded state map as an extra to the
      * instance state bundle to be used in {@link #onRestoreInstanceState(Bundle)}.
      *
@@ -364,11 +364,11 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     /**
      * Fetches the expandable state map from the saved instance state {@link Bundle}
      * and restores the expanded states of all of the list items.
-     * <p/>
+     * <p>
      * Should be called from {@link Activity#onRestoreInstanceState(Bundle)} in
      * the {@link Activity} that hosts the {@link RecyclerView} that this
      * {@link ExpandableRecyclerAdapter} is attached to.
-     * <p/>
+     * <p>
      * Assumes that the list of parent list items is the same as when the saved
      * instance state was stored.
      *

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -1,5 +1,6 @@
 package com.bignerdranch.expandablerecyclerview.Adapter;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
@@ -17,10 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 
 /**
- * The Base class for an Expandable RecyclerView Adapter
- *
- * Provides the base for a user to implement binding custom views to a Parent ViewHolder and a
- * Child ViewHolder
+ * {@link android.support.v7.widget.RecyclerView.Adapter} implementation that
+ * adds the ability to expand and collapse list items.
  *
  * @author Ryan Brooks
  * @version 1.0
@@ -33,15 +32,26 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     private static final int TYPE_PARENT = 0;
     private static final int TYPE_CHILD = 1;
 
+    /**
+     * A {@link List} of all currently expanded {@link ParentListItem} objects
+     * and their children, in order.
+     */
     protected List<Object> mItemList;
+
+    /**
+     * A {@link List} of all {@link ParentListItem} objects.
+     */
     protected List<? extends ParentListItem> mParentItemList;
+
     private ExpandCollapseListener mExpandCollapseListener;
     private List<RecyclerView> mAttachedRecyclerViewPool;
 
     /**
-     * Public constructor for the base ExpandableRecyclerView.
+     * Primary constructor. Sets up {@link #mParentItemList} and {@link #mItemList}.
      *
-     * @param parentItemList List of all parent objects that make up the recyclerview
+     * @param parentItemList List of all {@link ParentListItem} objects to be
+     *                       displayed in the {@link RecyclerView} that this
+     *                       adapter is linked to
      */
     public ExpandableRecyclerAdapter(@NonNull List<? extends ParentListItem> parentItemList) {
         super();
@@ -51,15 +61,16 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Override of RecyclerView's default onCreateViewHolder.
+     * Implementation of {@link android.support.v7.widget.RecyclerView.Adapter#onCreateViewHolder(ViewGroup, int)}
+     * that determines if the list item is a parent or a child and calls through
+     * to the appropriate implementation of either {@link #onCreateParentViewHolder(ViewGroup)}
+     * or {@link #onCreateChildViewHolder(ViewGroup)}.
      *
-     * This implementation determines if the item is a child or a parent view and will then call
-     * the respective onCreateViewHolder method that the user must implement in their custom
-     * implementation.
-     *
-     * @param viewGroup
-     * @param viewType
-     * @return the ViewHolder that corresponds to the item at the position.
+     * @param viewGroup The {@link ViewGroup} into which the new {@link android.view.View}
+     *                  will be added after it is bound to an adapter position.
+     * @param viewType The view type of the new {@code android.view.View}.
+     * @return A new {@link android.support.v7.widget.RecyclerView.ViewHolder}
+     *         that holds a {@code android.view.View} of the given view type.
      */
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
@@ -75,17 +86,16 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Override of RecyclerView's default onBindViewHolder
+     * Implementation of {@link android.support.v7.widget.RecyclerView.Adapter#onBindViewHolder(RecyclerView.ViewHolder, int)}
+     * that determines if the list item is a parent or a child and calls through
+     * to the appropriate implementation of either {@link #onBindParentViewHolder(ParentViewHolder, int, ParentListItem)}
+     * or {@link #onBindChildViewHolder(ChildViewHolder, int, Object)}.
      *
-     * This implementation determines first if the ViewHolder is a ParentViewHolder or a
-     * ChildViewHolder. The respective onBindViewHolders for ParentObjects and ChildObject are then
-     * called.
-     *
-     * If the item is a ParentObject, sets the entire row to trigger expansion if instructed to
-     *
-     * @param holder
-     * @param position
-     * @throws IllegalStateException if the item in the list is neither a ParentObject or ChildObject
+     * @param holder The {@link android.support.v7.widget.RecyclerView.ViewHolder}
+     *               to bind data to
+     * @param position The index in the list at which to bind
+     * @throws IllegalStateException if the item in the list is either {@value null}
+     *         or not of type {@link ParentListItem}
      */
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
@@ -108,43 +118,57 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Creates the Parent ViewHolder. Called from onCreateViewHolder when the item is a ParenObject.
+     * Callback called from {@link #onCreateViewHolder(ViewGroup, int)} when
+     * the list item created is a parent.
      *
-     * @param parentViewGroup
-     * @return ParentViewHolder that the user must create and inflate.
+     * @param parentViewGroup The {@link ViewGroup} in the list for which a {@link PVH}
+     *                        is being created
+     * @return A {@code PVH} corresponding to the {@link ParentListItem} with
+     *         the {@code ViewGroup} parentViewGroup
      */
     public abstract PVH onCreateParentViewHolder(ViewGroup parentViewGroup);
 
     /**
-     * Creates the Child ViewHolder. Called from onCreateViewHolder when the item is a ChildObject.
+     * Callback called from {@link #onCreateViewHolder(ViewGroup, int)} when
+     * the list item created is a child.
      *
-     * @param childViewGroup
-     * @return ChildViewHolder that the user must create and inflate.
+     * @param childViewGroup The {@link ViewGroup} in the list for which a {@link CVH}
+     *                       is being created
+     * @return A {@code CVH} corresponding to the child list item with the
+     *         {@code ViewGroup} childViewGroup
      */
     public abstract CVH onCreateChildViewHolder(ViewGroup childViewGroup);
 
     /**
-     * Binds the data to the ParentViewHolder. Called from onBindViewHolder when the item is a
-     * ParentObject
+     * Callback called from {@link #onBindViewHolder(RecyclerView.ViewHolder, int)}
+     * when the list item bound to is a parent.
+     * <p/>
+     * Bind data to the {@link PVH} here.
      *
-     * @param parentViewHolder
-     * @param position
+     * @param parentViewHolder The {@code PVH} to bind data to
+     * @param position The index in the list at which to bind
+     * @param parentListItem The {@link ParentListItem} which holds the data to
+     *                       be bound to the {@code PVH}
      */
-    public abstract void onBindParentViewHolder(PVH parentViewHolder, int position, Object parentObject);
+    public abstract void onBindParentViewHolder(PVH parentViewHolder, int position, ParentListItem parentListItem);
 
     /**
-     * Binds the data to the ChildViewHolder. Called from onBindViewHolder when the item is a
-     * ChildObject
+     * Callback called from {@link #onBindViewHolder(RecyclerView.ViewHolder, int)}
+     * when the list item bound to is a child.
+     * <p/>
+     * Bind data to the {@link CVH} here.
      *
-     * @param childViewHolder
-     * @param position
+     * @param childViewHolder The {@code CVH} to bind data to
+     * @param position The index in the list at which to bind
+     * @param childListItem The child list item which holds that data to be
+     *                      bound to the {@code CVH}
      */
-    public abstract void onBindChildViewHolder(CVH childViewHolder, int position, Object childObject);
+    public abstract void onBindChildViewHolder(CVH childViewHolder, int position, Object childListItem);
 
     /**
-     * Returns the size of the list that contains Parent and Child objects
+     * Gets the number of parent and child objects currently expanded.
      *
-     * @return integer value of the size of the Parent/Child list
+     * @return The size of {@link #mItemList}
      */
     @Override
     public int getItemCount() {
@@ -152,10 +176,11 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Returns the type of view that the item at the given position is.
+     * Gets the view type of the item at the given position.
      *
-     * @param position
-     * @return TYPE_PARENT (0) for ParentObjects and TYPE_CHILD (1) for ChildObjects
+     * @param position The index in the list to get the view type of
+     * @return {@value #TYPE_PARENT} for {@link ParentListItem} and {@value #TYPE_CHILD}
+     *         for child list items
      * @throws IllegalStateException if the item at the given position in the list is null
      */
     @Override
@@ -170,6 +195,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
     }
 
+    /**
+     * Implementation of {@link ParentListItemExpandCollapseListener#onParentListItemExpanded(int)}.
+     * Called when a {@link ParentListItem} is triggered to expand.
+     *
+     * @param position The index of the item in the list being expanded
+     */
     @Override
     public void onParentListItemExpanded(int position) {
         Object listItem = getListItem(position);
@@ -178,6 +209,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
     }
 
+    /**
+     * Implementation of {@link ParentListItemExpandCollapseListener#onParentListItemCollapsed(int)}.
+     * Called when a {@link ParentListItem} is triggered to collapse.
+     *
+     * @param position The index of the item in the list being collapsed
+     */
     @Override
     public void onParentListItemCollapsed(int position) {
         Object listItem = getListItem(position);
@@ -186,12 +223,26 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
     }
 
+    /**
+     * Implementation of {@link android.support.v7.widget.RecyclerView.Adapter#onAttachedToRecyclerView(RecyclerView)}.
+     * Called when this {@link ExpandableRecyclerAdapter} is attached to a {@link RecyclerView}.
+     *
+     * @param recyclerView The {@code RecyclerView} this {@code ExpandableRecyclerAdapter}
+     *                     is being attached to
+     */
     @Override
     public void onAttachedToRecyclerView(RecyclerView recyclerView) {
         super.onAttachedToRecyclerView(recyclerView);
         mAttachedRecyclerViewPool.add(recyclerView);
     }
 
+    /**
+     * Implementation of {@link android.support.v7.widget.RecyclerView.Adapter#onDetachedFromRecyclerView(RecyclerView)}.
+     * Called when this {@link ExpandableRecyclerAdapter} is detached from a {@link RecyclerView}
+     *
+     * @param recyclerView The {@code RecyclerView} this {@code ExpandableRecyclerAdapter}
+     *                     is being detached from
+     */
     @Override
     public void onDetachedFromRecyclerView(RecyclerView recyclerView) {
         super.onDetachedFromRecyclerView(recyclerView);
@@ -225,7 +276,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * Expands the parent associated with a specified {@link ParentListItem} in
      * the list of parents.
      *
-     * @param parentListItem The {@code ParentObject} of the parent to expand
+     * @param parentListItem The {@code ParentListItem} of the parent to expand
      */
     public void expandParent(ParentListItem parentListItem) {
         ParentWrapper parentWrapper = getParentWrapper(parentListItem);
@@ -249,7 +300,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     /**
      * Collapses the parent with the specified index in the list of parents.
      *
-     * @param parentIndex The index of the parent to expand
+     * @param parentIndex The index of the parent to collapse
      */
     public void collapseParent(int parentIndex) {
         int parentWrapperIndex = getParentWrapperIndex(parentIndex);
@@ -269,7 +320,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * Collapses the parent associated with a specified {@link ParentListItem} in
      * the list of parents.
      *
-     * @param parentListItem The {@code ParentObject} of the parent to collapse
+     * @param parentListItem The {@code ParentListItem} of the parent to collapse
      */
     public void collapseParent(ParentListItem parentListItem) {
         ParentWrapper parentWrapper = getParentWrapper(parentListItem);
@@ -291,184 +342,46 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Calls through to the {@link ParentViewHolder} to expand views for each
-     * {@link RecyclerView} a specified parent is a child of. These calls to
-     * the {@code ParentViewHolder} are made so that animations can be
-     * triggered at the {@link android.support.v7.widget.RecyclerView.ViewHolder}
-     * level.
+     * Stores the expanded state map across state loss.
+     * <p/>
+     * Should be called from {@link Activity#onSaveInstanceState(Bundle)} in
+     * the {@link Activity} that hosts the {@link RecyclerView} that this
+     * {@link ExpandableRecyclerAdapter} is attached to.
+     * <p/>
+     * This will make sure to add the expanded state map as an extra to the
+     * instance state bundle to be used in {@link #onRestoreInstanceState(Bundle)}.
      *
-     * @param parentIndex The index of the parent to expand
+     * @param savedInstanceState The {@code Bundle} into which to store the
+     *                           expanded state map
+     * @return The saved instance state {@code Bundle} with the expanded state
+     *         map added
      */
-    private void expandViews(ParentWrapper parentWrapper, int parentIndex) {
-        PVH viewHolder;
-        for (RecyclerView recyclerView : mAttachedRecyclerViewPool) {
-            viewHolder = (PVH) recyclerView.findViewHolderForAdapterPosition(parentIndex);
-            if (viewHolder != null && !viewHolder.isExpanded()) {
-                viewHolder.setExpanded(true);
-                viewHolder.onExpansionToggled(false);
-            }
-
-            expandParentListItem(parentWrapper, parentIndex, false);
-        }
+    public Bundle onSaveInstanceState(Bundle savedInstanceState) {
+        savedInstanceState.putSerializable(EXPANDED_STATE_MAP, generateExpandedStateMap());
+        return savedInstanceState;
     }
 
     /**
-     * Calls through to the {@link ParentViewHolder} to collapse views for each
-     * {@link RecyclerView} a specified parent is a child of. These calls to
-     * the {@code ParentViewHolder} are made so that animations can be
-     * triggered at the {@link android.support.v7.widget.RecyclerView.ViewHolder}
-     * level.
+     * Fetches the expandable state map from the saved instance state {@link Bundle}
+     * and restores the expanded states of all of the list items.
+     * <p/>
+     * Should be called from {@link Activity#onRestoreInstanceState(Bundle)} in
+     * the {@link Activity} that hosts the {@link RecyclerView} that this
+     * {@link ExpandableRecyclerAdapter} is attached to.
+     * <p/>
+     * Assumes that the list of parent list items is the same as when the saved
+     * instance state was stored.
      *
-     * @param parentIndex The index of the parent to collapse
+     * @param savedInstanceState The {@code Bundle} from which the expanded
+     *                           state map is loaded
      */
-    private void collapseViews(ParentWrapper parentWrapper, int parentIndex) {
-        PVH viewHolder;
-        for (RecyclerView recyclerView : mAttachedRecyclerViewPool) {
-            viewHolder = (PVH) recyclerView.findViewHolderForAdapterPosition(parentIndex);
-            if (viewHolder != null && viewHolder.isExpanded()) {
-                viewHolder.setExpanded(false);
-                viewHolder.onExpansionToggled(true);
-            }
-
-            collapseParentListItem(parentWrapper, parentIndex, false);
-        }
-    }
-
-    /**
-     * Expands a specified parent item. Calls through to the {@link ExpandCollapseListener}
-     * and adds children of the specified parent to the total list of items.
-     *
-     * @param parentWrapper The {@link ParentWrapper} of the parent to expand
-     * @param parentIndex The index of the parent to expand
-     * @param expansionTriggeredByListItemClick {@value true} if expansion was triggered by a
-     *                                                         click event, {@value false} otherwise.
-     */
-    private void expandParentListItem(ParentWrapper parentWrapper, int parentIndex, boolean expansionTriggeredByListItemClick) {
-        if (!parentWrapper.isExpanded()) {
-            parentWrapper.setExpanded(true);
-
-            if (expansionTriggeredByListItemClick && mExpandCollapseListener != null) {
-                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
-                mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
-            }
-
-            List<Object> childItemList = parentWrapper.getParentListItem().getChildItemList();
-            if (childItemList != null) {
-                int childListItemCount = childItemList.size();
-                for (int i = 0; i < childListItemCount; i++) {
-                    mItemList.add(parentIndex + i + 1, childItemList.get(i));
-                    notifyItemInserted(parentIndex + i + 1);
-                }
-            }
-        }
-    }
-
-    /**
-     * Collapses a specified parent item. Calls through to the {@link ExpandCollapseListener}
-     * and adds children of the specified parent to the total list of items.
-     *
-     * @param parentWrapper The {@link ParentWrapper} of the parent to collapse
-     * @param parentIndex The index of the parent to collapse
-     * @param collapseTriggeredByListItemClick {@value true} if expansion was triggered by a
-     *                                                         click event, {@value false} otherwise.
-     */
-    private void collapseParentListItem(ParentWrapper parentWrapper, int parentIndex, boolean collapseTriggeredByListItemClick) {
-        if (parentWrapper.isExpanded()) {
-            parentWrapper.setExpanded(false);
-
-            if (collapseTriggeredByListItemClick && mExpandCollapseListener != null) {
-                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
-                mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
-            }
-
-            List<Object> childItemList = parentWrapper.getParentListItem().getChildItemList();
-            if (childItemList != null) {
-                for (int i = childItemList.size() - 1; i >= 0; i--) {
-                    mItemList.remove(parentIndex + i + 1);
-                    notifyItemRemoved(parentIndex + i + 1);
-                }
-            }
-        }
-    }
-
-    /**
-     * Method to get the number of expanded children before the specified position.
-     *
-     * @param position
-     * @return number of expanded children before the specified position
-     */
-    private int getExpandedItemCount(int position) {
-        if (position == 0) {
-            return 0;
-        }
-
-        int expandedCount = 0;
-        for (int i = 0; i < position; i++) {
-            Object listItem = getListItem(i);
-            if (!(listItem instanceof ParentWrapper)) {
-                expandedCount++;
-            }
-        }
-        return expandedCount;
-    }
-
-    /**
-     * Generates a HashMap for storing expanded state when activity is rotated or onResume() is called.
-     *
-     * @param itemList
-     * @return HashMap containing the Parents expanded stated stored at the position relative to other parents
-     */
-    private HashMap<Integer, Boolean> generateExpandedStateMap(List<Object> itemList) {
-        HashMap<Integer, Boolean> parentListItemHashMap = new HashMap<>();
-        int childCount = 0;
-
-        Object listItem;
-        ParentWrapper parentWrapper;
-        int listItemCount = itemList.size();
-        for (int i = 0; i < listItemCount; i++) {
-            if (itemList.get(i) != null) {
-                listItem = getListItem(i);
-                if (listItem instanceof ParentWrapper) {
-                    parentWrapper = (ParentWrapper) listItem;
-                    parentListItemHashMap.put(i - childCount, parentWrapper.isExpanded());
-                } else {
-                    childCount++;
-                }
-            }
-        }
-
-        return parentListItemHashMap;
-    }
-
-    /**
-     * Should be called from onSaveInstanceState of Activity that holds the RecyclerView. This will
-     * make sure to add the generated HashMap as an extra to the bundle to be used in
-     * OnRestoreInstanceState().
-     *
-     * @param savedInstanceStateBundle
-     * @return the Bundle passed in with the Id HashMap added if applicable
-     */
-    public Bundle onSaveInstanceState(Bundle savedInstanceStateBundle) {
-        savedInstanceStateBundle.putSerializable(EXPANDED_STATE_MAP, generateExpandedStateMap(mItemList));
-        return savedInstanceStateBundle;
-    }
-
-    /**
-     * Should be called from onRestoreInstanceState of Activity that contains the ExpandingRecyclerView.
-     * This will fetch the HashMap that was saved in onSaveInstanceState() and use it to restore
-     * the expanded states before the rotation or onSaveInstanceState was called.
-     *
-     * Assumes list of parent objects is the same as when saveinstancestate was stored
-     *
-     * @param savedInstanceStateBundle
-     */
-    public void onRestoreInstanceState(Bundle savedInstanceStateBundle) {
-        if (savedInstanceStateBundle == null
-                || !savedInstanceStateBundle.containsKey(EXPANDED_STATE_MAP)) {
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        if (savedInstanceState == null
+                || !savedInstanceState.containsKey(EXPANDED_STATE_MAP)) {
             return;
         }
 
-        HashMap<Integer, Boolean> expandedStateMap = (HashMap<Integer, Boolean>) savedInstanceStateBundle.getSerializable(EXPANDED_STATE_MAP);
+        HashMap<Integer, Boolean> expandedStateMap = (HashMap<Integer, Boolean>) savedInstanceState.getSerializable(EXPANDED_STATE_MAP);
         int fullCount = 0;
         int childCount = 0;
         Object listItem;
@@ -515,18 +428,171 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Returns the list item held at the adapter position
+     * Gets the list item held at the specified adapter position.
      *
-     * @param position the index of the list item to return
-     * @return Object at that index, may be a ParentWrapper or child Object
+     * @param position The index of the list item to return
+     * @return The list item at the specified position
      */
     protected Object getListItem(int position) {
         return mItemList.get(position);
     }
 
     /**
-     * Gets the index of a {@link ParentWrapper} within the helper item list
-     * based on the index of the {@code ParentWrapper}.
+     * Calls through to the ParentViewHolder to expand views for each
+     * RecyclerView the specified parent is a child of.
+     *
+     * These calls to the ParentViewHolder are made so that animations can be
+     * triggered at the ViewHolder level.
+     *
+     * @param parentIndex The index of the parent to expand
+     */
+    private void expandViews(ParentWrapper parentWrapper, int parentIndex) {
+        PVH viewHolder;
+        for (RecyclerView recyclerView : mAttachedRecyclerViewPool) {
+            viewHolder = (PVH) recyclerView.findViewHolderForAdapterPosition(parentIndex);
+            if (viewHolder != null && !viewHolder.isExpanded()) {
+                viewHolder.setExpanded(true);
+                viewHolder.onExpansionToggled(false);
+            }
+
+            expandParentListItem(parentWrapper, parentIndex, false);
+        }
+    }
+
+    /**
+     * Calls through to the ParentViewHolder to collapse views for each
+     * RecyclerView a specified parent is a child of.
+     *
+     * These calls to the ParentViewHolder are made so that animations can be
+     * triggered at the ViewHolder level.
+     *
+     * @param parentIndex The index of the parent to collapse
+     */
+    private void collapseViews(ParentWrapper parentWrapper, int parentIndex) {
+        PVH viewHolder;
+        for (RecyclerView recyclerView : mAttachedRecyclerViewPool) {
+            viewHolder = (PVH) recyclerView.findViewHolderForAdapterPosition(parentIndex);
+            if (viewHolder != null && viewHolder.isExpanded()) {
+                viewHolder.setExpanded(false);
+                viewHolder.onExpansionToggled(true);
+            }
+
+            collapseParentListItem(parentWrapper, parentIndex, false);
+        }
+    }
+
+    /**
+     * Expands a specified parent item. Calls through to the
+     * ExpandCollapseListener and adds children of the specified parent to the
+     * total list of items.
+     *
+     * @param parentWrapper The ParentWrapper of the parent to expand
+     * @param parentIndex The index of the parent to expand
+     * @param expansionTriggeredByListItemClick true if expansion was triggered
+     *                                          by a click event, false otherwise.
+     */
+    private void expandParentListItem(ParentWrapper parentWrapper, int parentIndex, boolean expansionTriggeredByListItemClick) {
+        if (!parentWrapper.isExpanded()) {
+            parentWrapper.setExpanded(true);
+
+            if (expansionTriggeredByListItemClick && mExpandCollapseListener != null) {
+                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
+                mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
+            }
+
+            List<Object> childItemList = parentWrapper.getParentListItem().getChildItemList();
+            if (childItemList != null) {
+                int childListItemCount = childItemList.size();
+                for (int i = 0; i < childListItemCount; i++) {
+                    mItemList.add(parentIndex + i + 1, childItemList.get(i));
+                    notifyItemInserted(parentIndex + i + 1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Collapses a specified parent item. Calls through to the
+     * ExpandCollapseListener and adds children of the specified parent to the
+     * total list of items.
+     *
+     * @param parentWrapper The ParentWrapper of the parent to collapse
+     * @param parentIndex The index of the parent to collapse
+     * @param collapseTriggeredByListItemClick true if expansion was triggered
+     *                                         by a click event, false otherwise.
+     */
+    private void collapseParentListItem(ParentWrapper parentWrapper, int parentIndex, boolean collapseTriggeredByListItemClick) {
+        if (parentWrapper.isExpanded()) {
+            parentWrapper.setExpanded(false);
+
+            if (collapseTriggeredByListItemClick && mExpandCollapseListener != null) {
+                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
+                mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
+            }
+
+            List<Object> childItemList = parentWrapper.getParentListItem().getChildItemList();
+            if (childItemList != null) {
+                for (int i = childItemList.size() - 1; i >= 0; i--) {
+                    mItemList.remove(parentIndex + i + 1);
+                    notifyItemRemoved(parentIndex + i + 1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the number of expanded child list items before the specified position.
+     *
+     * @param position The index before which to return the number of expanded
+     *                 child list items
+     * @return The number of expanded child list items before the specified position
+     */
+    private int getExpandedItemCount(int position) {
+        if (position == 0) {
+            return 0;
+        }
+
+        int expandedCount = 0;
+        for (int i = 0; i < position; i++) {
+            Object listItem = getListItem(i);
+            if (!(listItem instanceof ParentWrapper)) {
+                expandedCount++;
+            }
+        }
+        return expandedCount;
+    }
+
+    /**
+     * Generates a HashMap used to store expanded state for items in the list
+     * on configuration change or whenever onResume is called.
+     *
+     * @return A HashMap containing the expanded state of all parent list items
+     */
+    private HashMap<Integer, Boolean> generateExpandedStateMap() {
+        HashMap<Integer, Boolean> parentListItemHashMap = new HashMap<>();
+        int childCount = 0;
+
+        Object listItem;
+        ParentWrapper parentWrapper;
+        int listItemCount = mItemList.size();
+        for (int i = 0; i < listItemCount; i++) {
+            if (mItemList.get(i) != null) {
+                listItem = getListItem(i);
+                if (listItem instanceof ParentWrapper) {
+                    parentWrapper = (ParentWrapper) listItem;
+                    parentListItemHashMap.put(i - childCount, parentWrapper.isExpanded());
+                } else {
+                    childCount++;
+                }
+            }
+        }
+
+        return parentListItemHashMap;
+    }
+
+    /**
+     * Gets the index of a ParentWrapper within the helper item list based on
+     * the index of the ParentWrapper.
      *
      * @param parentIndex The index of the parent in the list of parent items
      * @return The index of the parent in the list of all views in the adapter
@@ -548,12 +614,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Gets the {@link ParentWrapper} for a specified {@link ParentListItem} from
-     * the list of parents.
+     * Gets the ParentWrapper for a specified ParentListItem from the list of
+     * parents.
      *
-     * @param parentListItem A {@code ParentObject} in the list of parents
-     * @return If the parent exists on the list, returns its {@code ParentWrapper}.
-     *         Otherwise, returns {@value null}.
+     * @param parentListItem A ParentListItem in the list of parents
+     * @return If the parent exists on the list, returns its ParentWrapper.
+     *         Otherwise, returns null.
      */
     private ParentWrapper getParentWrapper(ParentListItem parentListItem) {
         int listItemCount = mItemList.size();

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -7,10 +7,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * Helper for {@link ExpandableRecyclerAdapter}.
+ *
  * Created by Ryan Brooks on 6/11/15.
  */
 public class ExpandableRecyclerAdapterHelper {
 
+    /**
+     * Generates a full list of all {@link ParentListItem} objects and their
+     * children, in order.
+     *
+     * @param parentItemList A list of the {@code ParentListItem} objects from
+     *                       the {@link ExpandableRecyclerAdapter}
+     * @return A list of all {@code ParentListItem} objects and their children, expanded
+     */
     public static List<Object> generateParentChildItemList(List<? extends ParentListItem> parentItemList) {
         List<Object> parentWrapperList = new ArrayList<>();
         ParentListItem parentListItem;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Listener/ExpandCollapseListener.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Listener/ExpandCollapseListener.java
@@ -1,8 +1,11 @@
 package com.bignerdranch.expandablerecyclerview.Listener;
 
 /**
- * Interface callback allowing objects to register themselves as expand/collapse listeners to be
+ * Allows objects to register themselves as expand/collapse listeners to be
  * notified of change events.
+ * <p/>
+ * Implement this in your {@link android.app.Activity} or {@link android.app.Fragment}
+ * to receive these callbacks.
  *
  * @author Evan Baker
  * @version 1.0
@@ -11,12 +14,16 @@ package com.bignerdranch.expandablerecyclerview.Listener;
 public interface ExpandCollapseListener {
 
     /**
-     * Method called when an item in the ExpandableRecycleView is expanded
+     * Called when a list item is expanded.
+     *
+     * @param position The index of the item in the list being expanded
      */
     void onListItemExpanded(int position);
 
     /**
-     * Method called when an item in the ExpandableRecyclerView is collapsed
+     * Called when a list item is collapsed.
+     *
+     * @param position The index of the item in the list being collapsed
      */
     void onListItemCollapsed(int position);
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Listener/ExpandCollapseListener.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Listener/ExpandCollapseListener.java
@@ -3,7 +3,7 @@ package com.bignerdranch.expandablerecyclerview.Listener;
 /**
  * Allows objects to register themselves as expand/collapse listeners to be
  * notified of change events.
- * <p/>
+ * <p>
  * Implement this in your {@link android.app.Activity} or {@link android.app.Fragment}
  * to receive these callbacks.
  *

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Listener/ParentListItemExpandCollapseListener.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Listener/ParentListItemExpandCollapseListener.java
@@ -1,7 +1,8 @@
 package com.bignerdranch.expandablerecyclerview.Listener;
 
 /**
- * Interface to allow for handling clicks of the ParentObject.
+ * Empowers {@link com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter}
+ * implementations to be notified of expand/collapse state change events.
  *
  * @author Ryan Brooks
  * @version 1.0
@@ -9,7 +10,18 @@ package com.bignerdranch.expandablerecyclerview.Listener;
  */
 public interface ParentListItemExpandCollapseListener {
 
+    /**
+     * Called when a list item is expanded.
+     *
+     * @param position The index of the item in the list being expanded
+     */
     void onParentListItemExpanded(int position);
+
+    /**
+     * Called when a list item is collapsed.
+     *
+     * @param position The index of the item in the list being collapsed
+     */
     void onParentListItemCollapsed(int position);
 
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentListItem.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentListItem.java
@@ -9,7 +9,7 @@ public interface ParentListItem {
 
     /**
      * Getter for the list of this parent list item's child list items.
-     * <p/>
+     * <p>
      * If list is empty, the parent list item has no children.
      *
      * @return A {@link List} of the children of this {@link ParentListItem}
@@ -20,7 +20,7 @@ public interface ParentListItem {
      * Getter used to determine if this {@link ParentListItem}'s
      * {@link android.view.View} should show up initially as expanded.
      *
-     * @return {@value true} if expanded, {@value false} if not
+     * @return true if expanded, false if not
      */
     boolean isInitiallyExpanded();
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentListItem.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentListItem.java
@@ -3,22 +3,24 @@ package com.bignerdranch.expandablerecyclerview.Model;
 import java.util.List;
 
 /**
- * Interface for implementing required methods in a ParentObject
+ * Interface for implementing required methods in a parent list item.
  */
 public interface ParentListItem {
 
     /**
-     * Getter method object to the reference to this ParentObject's child list. The list should
-     * contain all children to be displayed. If list is empty, no children will be added.
+     * Getter for the list of this parent list item's child list items.
+     * <p/>
+     * If list is empty, the parent list item has no children.
      *
-     * @return this Parent's child object
+     * @return A {@link List} of the children of this {@link ParentListItem}
      */
     List<Object> getChildItemList();
 
     /**
-     * Used to determine whether parent view should show up initially as expanded.
+     * Getter used to determine if this {@link ParentListItem}'s
+     * {@link android.view.View} should show up initially as expanded.
      *
-     * @return true if parent should be expanded
+     * @return {@value true} if expanded, {@value false} if not
      */
     boolean isInitiallyExpanded();
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -1,30 +1,59 @@
 package com.bignerdranch.expandablerecyclerview.Model;
 
 /**
- * Created by Ryan Brooks on 6/11/15.
+ * Wrapper used to link expanded state with a {@link ParentListItem}.
+ *
+ * @author Ryan Brooks
+ * @version 1.0
+ * @since 6/11/15
  */
 public class ParentWrapper {
 
     private boolean mExpanded;
     private ParentListItem mParentListItem;
 
+    /**
+     * Default constructor.
+     *
+     * @param parentListItem The {@link ParentListItem} to wrap
+     */
     public ParentWrapper(ParentListItem parentListItem) {
         mParentListItem = parentListItem;
         mExpanded = false;
     }
 
+    /**
+     * Gets the {@link ParentListItem} being wrapped.
+     *
+     * @return The {@link ParentListItem} being wrapped
+     */
     public ParentListItem getParentListItem() {
         return mParentListItem;
     }
 
+    /**
+     * Sets the {@link ParentListItem} to wrap.
+     *
+     * @param parentListItem The {@link ParentListItem} to wrap
+     */
     public void setParentListItem(ParentListItem parentListItem) {
         mParentListItem = parentListItem;
     }
 
+    /**
+     * Gets the expanded state associated with the {@link ParentListItem}.
+     *
+     * @return {@value true} if expanded, {@value false} if not
+     */
     public boolean isExpanded() {
         return mExpanded;
     }
 
+    /**
+     * Sets the expanded state associated with the {@link ParentListItem}.
+     *
+     * @param expanded {@value true} if expanded, {@value false} if not
+     */
     public void setExpanded(boolean expanded) {
         mExpanded = expanded;
     }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -43,7 +43,7 @@ public class ParentWrapper {
     /**
      * Gets the expanded state associated with the {@link ParentListItem}.
      *
-     * @return {@value true} if expanded, {@value false} if not
+     * @return true if expanded, false if not
      */
     public boolean isExpanded() {
         return mExpanded;
@@ -52,7 +52,7 @@ public class ParentWrapper {
     /**
      * Sets the expanded state associated with the {@link ParentListItem}.
      *
-     * @param expanded {@value true} if expanded, {@value false} if not
+     * @param expanded true if expanded, false if not
      */
     public void setExpanded(boolean expanded) {
         mExpanded = expanded;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ChildViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ChildViewHolder.java
@@ -4,8 +4,11 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 /**
- * ViewHolder for a ChildView that extends the base RecyclerView ViewHolder. The user should extend
- * this and implement as they wish for their ChildObject.
+ * {@link android.support.v7.widget.RecyclerView.ViewHolder} for a child list
+ * item.
+ * <p/>
+ * The user should extend this class and implement as they wish for their
+ * child list item.
  *
  * @author Ryan Brooks
  * @version 1.0
@@ -16,7 +19,7 @@ public class ChildViewHolder extends RecyclerView.ViewHolder {
     /**
      * Default constructor.
      *
-     * @param itemView
+     * @param itemView The {@link View} being hosted in this {@link android.support.v7.widget.RecyclerView.ViewHolder}
      */
     public ChildViewHolder(View itemView) {
         super(itemView);

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ChildViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ChildViewHolder.java
@@ -6,7 +6,7 @@ import android.view.View;
 /**
  * {@link android.support.v7.widget.RecyclerView.ViewHolder} for a child list
  * item.
- * <p/>
+ * <p>
  * The user should extend this class and implement as they wish for their
  * child list item.
  *

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -43,7 +43,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * Returns expanded state for the {@link com.bignerdranch.expandablerecyclerview.Model.ParentListItem}
      * corresponding to this {@link ParentViewHolder}.
      *
-     * @return {@value true} if expanded, {@value false} if not
+     * @return true if expanded, false if not
      */
     public boolean isExpanded() {
         return mExpanded;
@@ -53,7 +53,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * Setter method for expanded state, used for initialization of expanded state.
      * changes to the state are given in {@link #onExpansionToggled(boolean)}
      *
-     * @param expanded {@value true} if expanded, {@value false} if not
+     * @param expanded true if expanded, false if not
      */
     public void setExpanded(boolean expanded) {
         mExpanded = expanded;
@@ -62,10 +62,10 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     /**
      * Callback triggered when expansion state is changed, but not during
      * initialization.
-     * <p/>
+     * <p>
      * Useful for implementing animations on expansion.
      *
-     * @param expanded {@value true} if expanded, {@value false} if not
+     * @param expanded true if expanded, false if not
      */
     public void onExpansionToggled(boolean expanded) {
 
@@ -94,7 +94,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     /**
      * {@link android.view.View.OnClickListener} to listen for click events on
      * the entire parent {@link View}.
-     * <p/>
+     * <p>
      * Only registered if {@link #shouldItemViewClickToggleExpansion()} is true.
      *
      * @param v The {@link View} that is the trigger for expansion
@@ -111,12 +111,12 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     /**
      * Used to determine whether a click in the entire parent {@link View}
      * should trigger row expansion.
-     * <p/>
-     * If you return {@value false}, you can call {@link #expandView()} to
-     * trigger an expansion in response to a another event or
-     * {@link #collapseView()} to trigger a collapse.
+     * <p>
+     * If you return false, you can call {@link #expandView()} to trigger an
+     * expansion in response to a another event or {@link #collapseView()} to
+     * trigger a collapse.
      *
-     * @return {@value true} to set an {@link android.view.View.OnClickListener} on the item view
+     * @return true to set an {@link android.view.View.OnClickListener} on the item view
      */
     public boolean shouldItemViewClickToggleExpansion() {
         return true;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -7,8 +7,10 @@ import com.bignerdranch.expandablerecyclerview.Listener.ParentListItemExpandColl
 
 
 /**
- * ParentViewHolder that extends the Base RecyclerView ViewHolder. Keeps track of expansion and
- * offers the ability to animate in response to a triggered expansion
+ * {@link android.support.v7.widget.RecyclerView.ViewHolder} for a
+ * {@link com.bignerdranch.expandablerecyclerview.Model.ParentListItem}.
+ * Keeps track of expanded state and holds callbacks which can be used to
+ * trigger expansion-based events.
  *
  * @author Ryan Brooks
  * @version 1.0
@@ -20,8 +22,9 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     private boolean mExpanded;
 
     /**
-     * Default constructor
-     * @param itemView view that will be shown for this ViewHolder
+     * Default constructor.
+     *
+     * @param itemView The {@link View} being hosted in this {@link android.support.v7.widget.RecyclerView.ViewHolder}
      */
     public ParentViewHolder(View itemView) {
         super(itemView);
@@ -29,16 +32,18 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
-     * Sets the Parent only as the trigger to expand the item.
+     * Sets a {@link android.view.View.OnClickListener} on the entire parent
+     * view to trigger expansion.
      */
     public void setMainItemClickToExpand() {
         itemView.setOnClickListener(this);
     }
 
     /**
-     * Returns if the item is currently expanded.
+     * Returns expanded state for the {@link com.bignerdranch.expandablerecyclerview.Model.ParentListItem}
+     * corresponding to this {@link ParentViewHolder}.
      *
-     * @return true if expanded, false if not
+     * @return {@value true} if expanded, {@value false} if not
      */
     public boolean isExpanded() {
         return mExpanded;
@@ -48,44 +53,51 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * Setter method for expanded state, used for initialization of expanded state.
      * changes to the state are given in {@link #onExpansionToggled(boolean)}
      *
-     * @param expanded
+     * @param expanded {@value true} if expanded, {@value false} if not
      */
     public void setExpanded(boolean expanded) {
         mExpanded = expanded;
     }
 
     /**
-     * Called when expansion is changed, does not get called during the initial binding
-     * Useful for implementing parent view animations for expansion
-     * @param expanded
+     * Callback triggered when expansion state is changed, but not during
+     * initialization.
+     * <p/>
+     * Useful for implementing animations on expansion.
+     *
+     * @param expanded {@value true} if expanded, {@value false} if not
      */
     public void onExpansionToggled(boolean expanded) {
 
     }
 
     /**
-     * Getter for the ParentItemClickListener passed from the ExpandableRecyclerAdapter
+     * Getter for the {@link ParentListItemExpandCollapseListener} implemented in
+     * {@link com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter}.
      *
-     * @return the ViewHolder's set ParentItemClickListner
+     * @return The {@link ParentListItemExpandCollapseListener} set in the {@link ParentViewHolder}
      */
     public ParentListItemExpandCollapseListener getParentListItemExpandCollapseListener() {
         return mParentListItemExpandCollapseListener;
     }
 
     /**
-     * Setter for the ParentItemClickListener implemented in ExpandableRecyclerAdapter
+     * Setter for the {@link ParentListItemExpandCollapseListener} implemented in
+     * {@link com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter}.
      *
-     * @param mParentListItemExpandCollapseListener
+     * @param parentListItemExpandCollapseListener The {@link ParentListItemExpandCollapseListener} to set on the {@link ParentViewHolder}
      */
-    public void setParentListItemExpandCollapseListener(ParentListItemExpandCollapseListener mParentListItemExpandCollapseListener) {
-        this.mParentListItemExpandCollapseListener = mParentListItemExpandCollapseListener;
+    public void setParentListItemExpandCollapseListener(ParentListItemExpandCollapseListener parentListItemExpandCollapseListener) {
+        mParentListItemExpandCollapseListener = parentListItemExpandCollapseListener;
     }
 
     /**
-     * Implementation of View.onClick to listen for the clicks on the entire row.
-     * Only registered if {@link #shouldItemViewClickToggleExpansion()} is true
+     * {@link android.view.View.OnClickListener} to listen for click events on
+     * the entire parent {@link View}.
+     * <p/>
+     * Only registered if {@link #shouldItemViewClickToggleExpansion()} is true.
      *
-     * @param v the view that is the trigger for expansion
+     * @param v The {@link View} that is the trigger for expansion
      */
     @Override
     public void onClick(View v) {
@@ -97,19 +109,21 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
-     * Used to determine whether the entire row should trigger row expansion,
-     * if you return false, call {@link #expandView()} to toggle an expansion
-     * in response to a click in your custom view or {@link #collapseView()} to
-     * toggle a collapse.
+     * Used to determine whether a click in the entire parent {@link View}
+     * should trigger row expansion.
+     * <p/>
+     * If you return {@value false}, you can call {@link #expandView()} to
+     * trigger an expansion in response to a another event or
+     * {@link #collapseView()} to trigger a collapse.
      *
-     * @return true to set a click listener on the item view that toggles expansion
+     * @return {@value true} to set an {@link android.view.View.OnClickListener} on the item view
      */
     public boolean shouldItemViewClickToggleExpansion() {
         return true;
     }
 
     /**
-     * Triggers expansion of the parent list item.
+     * Triggers expansion of the parent.
      */
     protected void expandView() {
         setExpanded(true);
@@ -121,7 +135,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     }
 
     /**
-     * Triggers collapse of the parent list item.
+     * Triggers collapse of the parent.
      */
     protected void collapseView() {
         setExpanded(false);


### PR DESCRIPTION
Cleaned up Javadocs in the library. Also replaced mentions of "Object" in reference to parents and children in the sample.

Worked around Travis errors by downgrading our JDK version to 7 in .travis.yml.
*Note:* The big chunk of code moved in `ExpandableRecyclerAdapter was moved so that all `private` methods are at the bottom of the class.