### PR TITLE
Removed extraneous return statement from onSavedInstanceState call

### DIFF
--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -95,7 +95,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState = mExpandableAdapter.onSaveInstanceState(outState);
+        mExpandableAdapter.onSaveInstanceState(outState);
     }
 
     /**

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
@@ -67,7 +67,7 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState = mExpandableAdapter.onSaveInstanceState(outState);
+        mExpandableAdapter.onSaveInstanceState(outState);
     }
 
     /**

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -385,12 +385,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      *
      * @param savedInstanceState The {@code Bundle} into which to store the
      *                           expanded state map
-     * @return The saved instance state {@code Bundle} with the expanded state
-     *         map added
      */
-    public Bundle onSaveInstanceState(Bundle savedInstanceState) {
+    public void onSaveInstanceState(Bundle savedInstanceState) {
         savedInstanceState.putSerializable(EXPANDED_STATE_MAP, generateExpandedStateMap());
-        return savedInstanceState;
     }
 
     /**


### PR DESCRIPTION
`ExpandableRecyclerAdapter` has its own version of `#onSavedInstanceState(Bundle)` that was returning a `Bundle`. Because you were passing in the `Bundle` that you wanted to modify, returning that same `Bundle` was unnecessary because you already have the object reference.