### PR TITLE
notify data set inserted/removed/modified methods

### DIFF
--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -24,6 +24,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
 
     private static final int NUM_TEST_DATA_ITEMS = 20;
     private static final int EXPAND_COLLAPSE_SINGLE_PARENT_INDEX = 2;
+    private static final String SAVED_TEST_DATA_ITEM_LIST = "HorizontalLinearRecyclerViewSampleActivity.SavedTestDataItemList";
 
     private Toolbar mToolbar;
     private RecyclerView mRecyclerView;
@@ -32,7 +33,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
     private Button mExpandAllButton;
     private Button mCollapseAllButton;
 
-    private List<HorizontalParent> mTestDataItemList;
+    private ArrayList<HorizontalParent> mTestDataItemList;
 
     private HorizontalExpandableAdapter mExpandableAdapter;
 
@@ -85,7 +86,11 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         addMultipleParents.setOnClickListener(mAddMultipleParentsClickListener);
 
         // Create a new adapter with 20 test data items
-        mTestDataItemList = setUpTestData(NUM_TEST_DATA_ITEMS);
+        if (savedInstanceState == null) {
+            mTestDataItemList = setUpTestData(NUM_TEST_DATA_ITEMS);
+        } else {
+            mTestDataItemList = (ArrayList<HorizontalParent>) savedInstanceState.getSerializable(SAVED_TEST_DATA_ITEM_LIST);
+        }
         mExpandableAdapter = new HorizontalExpandableAdapter(this, mTestDataItemList);
 
         // Attach this activity to the Adapter as the ExpandCollapseListener
@@ -105,6 +110,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState = mExpandableAdapter.onSaveInstanceState(outState);
+        outState.putSerializable(SAVED_TEST_DATA_ITEM_LIST, mTestDataItemList);
     }
 
     /**
@@ -344,8 +350,8 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
      *
      * @return A List of Objects that contains all parent items. Expansion of children are handled in the adapter
      */
-    private List<HorizontalParent> setUpTestData(int numItems) {
-        List<HorizontalParent> horizontalParentList = new ArrayList<>();
+    private ArrayList<HorizontalParent> setUpTestData(int numItems) {
+        ArrayList<HorizontalParent> horizontalParentList = new ArrayList<>();
 
         for (int i = 0; i < numItems; i++) {
             List<HorizontalChild> childItemList = new ArrayList<>();

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -246,9 +246,10 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
 
             HorizontalParent horizontalParent = mTestDataItemList.get(1);
             HorizontalChild horizontalChild = new HorizontalChild();
-            horizontalChild.setChildText(getString(R.string.added_child, horizontalParent.getChildItemList().size()));
-            horizontalParent.getChildItemList().add(horizontalChild);
-            mExpandableAdapter.addChild(1, 1, horizontalParent, horizontalChild);
+            List<HorizontalChild> childList = horizontalParent.getChildItemList();
+            horizontalChild.setChildText(getString(R.string.added_child, childList.size()));
+            childList.add(horizontalChild);
+            mExpandableAdapter.notifyChildItemInserted(1, childList.size() - 1);
         }
     };
 
@@ -266,7 +267,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
             }
 
             childList.remove(1);
-            mExpandableAdapter.removeChild(1, 1, horizontalParent);
+            mExpandableAdapter.notifyChildItemRemoved(1, 1);
         }
     };
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -222,8 +222,8 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
             }
 
             HorizontalParent horizontalParent = mTestDataItemList.get(1);
-            mExpandableAdapter.removeParent(horizontalParent);
             mTestDataItemList.remove(horizontalParent);
+            mExpandableAdapter.notifyParentItemRemoved(1);
 
         }
     };
@@ -231,8 +231,9 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
     private OnClickListener mRemoveFromEndClickListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
-            mExpandableAdapter.removeParent(mTestDataItemList.size() - 1);
-            mTestDataItemList.remove(mTestDataItemList.size() - 1);
+            int removeIndex = mTestDataItemList.size() - 1;
+            mTestDataItemList.remove(removeIndex);
+            mExpandableAdapter.notifyParentItemRemoved(removeIndex);
         }
     };
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -81,6 +81,9 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         Button removeChild = (Button) findViewById(R.id.activity_horizontal_linear_recycler_view_remove_child);
         removeChild.setOnClickListener(mRemoveChildClickListener);
 
+        Button addMultipleParents = (Button) findViewById(R.id.activity_horizontal_linear_recycler_view_add_multiple_parents);
+        addMultipleParents.setOnClickListener(mAddMultipleParentsClickListener);
+
         // Create a new adapter with 20 test data items
         mTestDataItemList = setUpTestData(NUM_TEST_DATA_ITEMS);
         mExpandableAdapter = new HorizontalExpandableAdapter(this, mTestDataItemList);
@@ -268,6 +271,57 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
 
             childList.remove(1);
             mExpandableAdapter.notifyChildItemRemoved(1, 1);
+        }
+    };
+
+    private OnClickListener mAddMultipleParentsClickListener = new OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            // Adds first parent
+            ArrayList<HorizontalChild> childList = new ArrayList<>();
+            int parentNumber = mTestDataItemList.size();
+
+            HorizontalChild horizontalChild = new HorizontalChild();
+            horizontalChild.setChildText(getString(R.string.child_insert_text, 1));
+            childList.add(horizontalChild);
+
+            horizontalChild = new HorizontalChild();
+            horizontalChild.setChildText(getString(R.string.child_insert_text, 2));
+            childList.add(horizontalChild);
+
+            HorizontalParent horizontalParent = new HorizontalParent();
+            horizontalParent.setChildItemList(childList);
+            horizontalParent.setParentNumber(parentNumber);
+            horizontalParent.setParentText(getString(R.string.inserted_parent_text));
+            if (parentNumber % 2 == 0) {
+                horizontalParent.setInitiallyExpanded(true);
+            }
+
+
+            mTestDataItemList.add(1, horizontalParent);
+
+            childList = new ArrayList<>();
+            parentNumber = mTestDataItemList.size();
+
+            horizontalChild = new HorizontalChild();
+            horizontalChild.setChildText(getString(R.string.child_insert_text, 1));
+            childList.add(horizontalChild);
+
+            horizontalChild = new HorizontalChild();
+            horizontalChild.setChildText(getString(R.string.child_insert_text, 2));
+            childList.add(horizontalChild);
+
+            horizontalParent = new HorizontalParent();
+            horizontalParent.setChildItemList(childList);
+            horizontalParent.setParentNumber(parentNumber);
+            horizontalParent.setParentText(getString(R.string.inserted_parent_text));
+            if (parentNumber % 2 == 0) {
+                horizontalParent.setInitiallyExpanded(true);
+            }
+
+            mTestDataItemList.add(2, horizontalParent);
+
+            mExpandableAdapter.notifyParentItemRangeInserted(1, 2);
         }
     };
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -78,6 +78,9 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         Button addChild = (Button) findViewById(R.id.activity_horizontal_linear_recycler_view_add_child);
         addChild.setOnClickListener(mAddChildClickListener);
 
+        Button removeChild = (Button) findViewById(R.id.activity_horizontal_linear_recycler_view_remove_child);
+        removeChild.setOnClickListener(mRemoveChildClickListener);
+
         // Create a new adapter with 20 test data items
         mTestDataItemList = setUpTestData(NUM_TEST_DATA_ITEMS);
         mExpandableAdapter = new HorizontalExpandableAdapter(this, mTestDataItemList);
@@ -245,6 +248,24 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
             horizontalChild.setChildText(getString(R.string.added_child, horizontalParent.getChildItemList().size()));
             horizontalParent.getChildItemList().add(horizontalChild);
             mExpandableAdapter.addChild(1, 1, horizontalParent, horizontalChild);
+        }
+    };
+
+    private OnClickListener mRemoveChildClickListener = new OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            if (mTestDataItemList.size() < 2) {
+                return;
+            }
+
+            HorizontalParent horizontalParent = mTestDataItemList.get(1);
+            List<HorizontalChild> childList = horizontalParent.getChildItemList();
+            if (childList.size() < 2) {
+                return;
+            }
+
+            childList.remove(1);
+            mExpandableAdapter.removeChild(1, 1, horizontalParent);
         }
     };
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -182,8 +182,8 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
             }
 
 
-            mExpandableAdapter.addParent(horizontalParent);
             mTestDataItemList.add(horizontalParent);
+            mExpandableAdapter.notifyParentItemInserted(mTestDataItemList.size() - 1);
         }
     };
 
@@ -209,8 +209,8 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
                 horizontalParent.setInitiallyExpanded(true);
             }
 
-            mExpandableAdapter.addParent(1, horizontalParent);
             mTestDataItemList.add(1, horizontalParent);
+            mExpandableAdapter.notifyParentItemInserted(1);
         }
     };
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -75,6 +75,9 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         Button removeSecondbutton = (Button) findViewById(R.id.activity_horizontal_linear_recycler_view_remove_second_button);
         removeSecondbutton.setOnClickListener(mRemoveSecondClickListener);
 
+        Button addChild = (Button) findViewById(R.id.activity_horizontal_linear_recycler_view_add_child);
+        addChild.setOnClickListener(mAddChildClickListener);
+
         // Create a new adapter with 20 test data items
         mTestDataItemList = setUpTestData(NUM_TEST_DATA_ITEMS);
         mExpandableAdapter = new HorizontalExpandableAdapter(this, mTestDataItemList);
@@ -227,6 +230,21 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         public void onClick(View v) {
             mExpandableAdapter.removeParent(mTestDataItemList.size() - 1);
             mTestDataItemList.remove(mTestDataItemList.size() - 1);
+        }
+    };
+
+    private OnClickListener mAddChildClickListener = new OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            if (mTestDataItemList.size() < 2) {
+                return;
+            }
+
+            HorizontalParent horizontalParent = mTestDataItemList.get(1);
+            HorizontalChild horizontalChild = new HorizontalChild();
+            horizontalChild.setChildText(getString(R.string.added_child, horizontalParent.getChildItemList().size()));
+            horizontalParent.getChildItemList().add(horizontalChild);
+            mExpandableAdapter.addChild(1, 1, horizontalParent, horizontalChild);
         }
     };
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -152,7 +152,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         @Override
         public void onClick(View v) {
 
-            ArrayList<Object> childList = new ArrayList<>();
+            ArrayList<HorizontalChild> childList = new ArrayList<>();
             int parentNumber = mTestDataItemList.size();
 
             HorizontalChild horizontalChild = new HorizontalChild();
@@ -184,7 +184,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
     private OnClickListener mAddToSecondClickListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
-            ArrayList<Object> childList = new ArrayList<>();
+            ArrayList<HorizontalChild> childList = new ArrayList<>();
             int parentNumber = mTestDataItemList.size();
 
             HorizontalChild horizontalChild = new HorizontalChild();
@@ -253,7 +253,7 @@ public class HorizontalLinearRecyclerViewSampleActivity extends AppCompatActivit
         List<HorizontalParent> horizontalParentList = new ArrayList<>();
 
         for (int i = 0; i < numItems; i++) {
-            List<Object> childItemList = new ArrayList<>();
+            List<HorizontalChild> childItemList = new ArrayList<>();
 
             HorizontalChild horizontalChild = new HorizontalChild();
             horizontalChild.setChildText(getString(R.string.child_text, i));

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParent.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParent.java
@@ -12,9 +12,7 @@ import java.util.List;
  */
 public class HorizontalParent implements ParentListItem {
 
-    // A List<Object> or subclass of List must be added for the object to work correctly
-    private List<Object> mChildItemList;
-
+    private List<HorizontalChild> mChildItemList;
     private String mParentText;
     private int mParentNumber;
     private boolean mInitiallyExpanded;
@@ -41,7 +39,7 @@ public class HorizontalParent implements ParentListItem {
      * @return list of all children associated with this specific parent list item
      */
     @Override
-    public List<Object> getChildItemList() {
+    public List<HorizontalChild> getChildItemList() {
         return mChildItemList;
     }
 
@@ -50,7 +48,7 @@ public class HorizontalParent implements ParentListItem {
      *
      * @param childItemList the list of all children associated with this parent list item
      */
-    public void setChildItemList(List<Object> childItemList) {
+    public void setChildItemList(List<HorizontalChild> childItemList) {
         mChildItemList = childItemList;
     }
 

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
@@ -115,7 +115,7 @@ public class VerticalLinearRecyclerViewSampleActivity extends AppCompatActivity 
         List<VerticalParent> verticalParentList = new ArrayList<>();
 
         for (int i = 0; i < numItems; i++) {
-            List<Object> childItemList = new ArrayList<>();
+            List<VerticalChild> childItemList = new ArrayList<>();
 
             VerticalChild verticalChild = new VerticalChild();
             verticalChild.setChildText(getString(R.string.child_text, i));

--- a/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParent.java
+++ b/app/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalParent.java
@@ -16,8 +16,7 @@ import java.util.List;
  */
 public class VerticalParent implements ParentListItem {
 
-    // A List<Object> or subclass of List must be added for the object to work correctly
-    private List<Object> mChildItemList;
+    private List<VerticalChild> mChildItemList;
     private String mParentText;
     private int mParentNumber;
     private boolean mInitiallyExpanded;
@@ -44,7 +43,7 @@ public class VerticalParent implements ParentListItem {
      * @return list of all children associated with this specific parent list item
      */
     @Override
-    public List<Object> getChildItemList() {
+    public List<VerticalChild> getChildItemList() {
         return mChildItemList;
     }
 
@@ -53,7 +52,7 @@ public class VerticalParent implements ParentListItem {
      *
      * @param childItemList the list of all children associated with this parent list item
      */
-    public void setChildItemList(List<Object> childItemList) {
+    public void setChildItemList(List<VerticalChild> childItemList) {
         mChildItemList = childItemList;
     }
 

--- a/app/src/main/res/layout/activity_horizontal_linear_recycler_view_sample.xml
+++ b/app/src/main/res/layout/activity_horizontal_linear_recycler_view_sample.xml
@@ -92,4 +92,24 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="@dimen/margin_medium">
+
+        <Button
+            android:id="@+id/activity_horizontal_linear_recycler_view_add_child"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/add_child"/>
+
+        <Button
+            android:id="@+id/activity_horizontal_linear_recycler_view_remove_child"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/remove_child"/>
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_horizontal_linear_recycler_view_sample.xml
+++ b/app/src/main/res/layout/activity_horizontal_linear_recycler_view_sample.xml
@@ -112,4 +112,18 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="@dimen/margin_medium">
+
+        <Button
+            android:id="@+id/activity_horizontal_linear_recycler_view_add_multiple_parents"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/add_multiple_parents"/>
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_horizontal_linear_recycler_view_sample.xml
+++ b/app/src/main/res/layout/activity_horizontal_linear_recycler_view_sample.xml
@@ -20,14 +20,16 @@
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_expand_parent_two_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/expand_parent_two"/>
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_collapse_parent_two_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/collapse_parent_two"/>
 
     </LinearLayout>
@@ -40,14 +42,16 @@
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_expand_all_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/expand_all"/>
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_collapse_all_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/collapse_all"/>
 
     </LinearLayout>
@@ -60,14 +64,16 @@
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_add_to_end_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/add_item_to_end"/>
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_remove_from_end_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/remove_item_from_end"/>
 
     </LinearLayout>
@@ -80,14 +86,16 @@
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_add_to_second_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/add_item_at_pos_two"/>
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_remove_second_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/remove_second_pos"/>
 
     </LinearLayout>
@@ -100,14 +108,16 @@
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_add_child"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/add_child"/>
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_remove_child"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/remove_child"/>
 
     </LinearLayout>
@@ -120,8 +130,9 @@
 
         <Button
             android:id="@+id/activity_horizontal_linear_recycler_view_add_multiple_parents"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/add_multiple_parents"/>
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,8 +29,8 @@
     <string name="remove_item_from_end">Remove parent from end</string>
     <string name="add_item_at_pos_two">Add parent @ pos 1</string>
     <string name="remove_second_pos">Remove parent @ pos 1</string>
-    <string name="add_child">Add child to 2nd parent</string>
-    <string name="remove_child">Remove child on 2nd parent</string>
+    <string name="add_child">Add child to end of 2nd parent</string>
+    <string name="remove_child">Remove child on 2nd parent from pos 1</string>
     <string name="added_child">Child Addition %1$d</string>
     <string name="add_multiple_parents">Add 2 Parents @ pos 1</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="add_child">Add child to 2nd parent</string>
     <string name="remove_child">Rem child on 2nd parent</string>
     <string name="added_child">Child Addition %1$d</string>
+    <string name="add_multiple_parents">Add 2 Parents @ pos 1</string>
 
     <!-- Sample Toolbar -->
     <string name="no_animation">No animation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="add_item_at_pos_two">Add parent @ pos 1</string>
     <string name="remove_second_pos">Remove parent @ pos 1</string>
     <string name="add_child">Add child to 2nd parent</string>
-    <string name="remove_child">Rem child on 2nd parent</string>
+    <string name="remove_child">Remove child on 2nd parent</string>
     <string name="added_child">Child Addition %1$d</string>
     <string name="add_multiple_parents">Add 2 Parents @ pos 1</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="remove_item_from_end">Remove parent from end</string>
     <string name="add_item_at_pos_two">Add parent @ pos 1</string>
     <string name="remove_second_pos">Remove parent @ pos 1</string>
+    <string name="add_child">Add child to 2nd parent</string>
+    <string name="remove_child">Rem child on 2nd parent</string>
+    <string name="added_child">Child Addition %1$d</string>
 
     <!-- Sample Toolbar -->
     <string name="no_animation">No animation</string>

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/Crime.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/Crime.java
@@ -12,7 +12,7 @@ public class Crime implements ParentListItem {
     private String mTitle;
     private Date mDate;
     private boolean mSolved;
-    private List<Object> mChildItemList;
+    private List<CrimeChild> mChildItemList;
 
     public Crime() {
         mId = UUID.randomUUID();
@@ -48,11 +48,11 @@ public class Crime implements ParentListItem {
     }
 
     @Override
-    public List<Object> getChildItemList() {
+    public List<CrimeChild> getChildItemList() {
         return mChildItemList;
     }
 
-    public void setChildItemList(List<Object> list) {
+    public void setChildItemList(List<CrimeChild> list) {
         mChildItemList = list;
     }
 

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
@@ -43,7 +43,7 @@ public class CrimeListFragment extends Fragment {
         List<Crime> crimes = crimeLab.getCrimes();
         List<ParentListItem> parentListItems = new ArrayList<>();
         for (Crime crime : crimes) {
-            List<Object> childItemList = new ArrayList<>();
+            List<CrimeChild> childItemList = new ArrayList<>();
             childItemList.add(new CrimeChild(crime.getDate(), crime.isSolved()));
             crime.setChildItemList(childItemList);
             parentListItems.add(crime);

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -696,6 +696,17 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         return parentListItem;
     }
 
+    public void addChild(int parentPosition, int childPosition, ParentListItem newParentListItem, Object child) {
+        int parentWrapperIndex = getParentWrapperIndex(parentPosition);
+        ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
+        parentWrapper.setParentListItem(newParentListItem);
+        parentWrapper.getChildItemList().add(childPosition, child);
+        if (parentWrapper.isExpanded()) {
+            mItemList.add(parentWrapperIndex + childPosition + 1, child);
+            notifyItemInserted(parentWrapperIndex + childPosition + 1);
+        }
+    }
+
 
     // endregion
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -696,15 +696,35 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         return parentListItem;
     }
 
-    public void addChild(int parentPosition, int childPosition, ParentListItem newParentListItem, Object child) {
+    public void addChild(int parentPosition, int childPosition, ParentListItem updatedParentListItem, Object child) {
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
-        parentWrapper.setParentListItem(newParentListItem);
+        parentWrapper.setParentListItem(updatedParentListItem);
         parentWrapper.getChildItemList().add(childPosition, child);
         if (parentWrapper.isExpanded()) {
             mItemList.add(parentWrapperIndex + childPosition + 1, child);
             notifyItemInserted(parentWrapperIndex + childPosition + 1);
         }
+    }
+
+    public Object removeChild(int parentPosition, int childPosition, ParentListItem updatedParentListItem) {
+        int parentWrapperIndex = getParentWrapperIndex(parentPosition);
+        if (parentWrapperIndex == -1) {
+            return null;
+        }
+        ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
+        List<Object> childItems = parentWrapper.getChildItemList();
+        if (childPosition >= childItems.size()) {
+            return null;
+        }
+
+        Object removedChild = childItems.remove(childPosition);
+        if (parentWrapper.isExpanded()) {
+            mItemList.remove(parentWrapperIndex + childPosition + 1);
+            notifyItemRemoved(parentWrapperIndex + childPosition + 1);
+        }
+        parentWrapper.setParentListItem(updatedParentListItem);
+        return removedChild;
     }
 
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -608,10 +608,32 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             wrapperIndex = mItemList.size();
         }
 
-        addParentWrapper(wrapperIndex, parentListItem);
+        int sizeChanged = addParentWrapper(wrapperIndex, parentListItem);
+        notifyItemRangeInserted(wrapperIndex, sizeChanged);
     }
 
-    private void addParentWrapper(int wrapperIndex, ParentListItem parentListItem) {
+    public void notifyParentItemRangeInserted(int parentPosition, int itemCount) {
+        int initialWrapperIndex;
+        if (parentPosition < mParentItemList.size() - 1) {
+            initialWrapperIndex = getParentWrapperIndex(parentPosition);
+        } else {
+            initialWrapperIndex = mItemList.size();
+        }
+
+        int sizeChanged = 0;
+        int wrapperIndex = initialWrapperIndex;
+        int changed;
+        for (int i = parentPosition; i < parentPosition + itemCount; i++) {
+            ParentListItem parentListItem = mParentItemList.get(i);
+            changed = addParentWrapper(wrapperIndex, parentListItem);
+            wrapperIndex += changed;
+            sizeChanged += changed;
+        }
+
+        notifyItemRangeInserted(initialWrapperIndex, sizeChanged);
+    }
+
+    private int addParentWrapper(int wrapperIndex, ParentListItem parentListItem) {
         int sizeChanged = 1;
         ParentWrapper parentWrapper = new ParentWrapper(parentListItem);
         mItemList.add(wrapperIndex, parentWrapper);
@@ -621,7 +643,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             mItemList.addAll(wrapperIndex + sizeChanged, childItemList);
             sizeChanged += childItemList.size();
         }
-        notifyItemRangeInserted(wrapperIndex, sizeChanged);
+        return sizeChanged;
     }
 
     public void notifyParentItemRemoved(int parentPosition) {

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -47,11 +47,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     protected List<Object> mItemList;
 
-    /**
-     * A {@link List} of all {@link ParentListItem} objects.
-     */
-    protected List<? extends ParentListItem> mParentItemList;
-
+    private List<? extends ParentListItem> mParentItemList;
     private ExpandCollapseListener mExpandCollapseListener;
     private List<RecyclerView> mAttachedRecyclerViewPool;
 
@@ -244,7 +240,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      * methods.
      *
      *
-     * @return
+     * @return The list of ParentListItems that this adapter represents
      */
     public List<? extends ParentListItem> getParentItemList() {
         return mParentItemList;
@@ -628,13 +624,13 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     // region Data Manipulation
 
     /**
-     * Notify any registered observers that the ParentListItem reflected at <code>parentPosition</code>
-     * has been newly inserted. The ParentListItem previously at <code>parentPosition</code> is now at
-     * position <code>parentPosition + 1</code>.
-     *
-     * <p>This is a structural change event. Representations of other existing items in the
+     * Notify any registered observers that the ParentListItem reflected at {@code parentPosition}
+     * has been newly inserted. The ParentListItem previously at {@code parentPosition} is now at
+     * position {@code parentPosition + 1}.
+     * <p>
+     * This is a structural change event. Representations of other existing items in the
      * data set are still considered up to date and will not be rebound, though their
-     * positions may be altered.</p>
+     * positions may be altered.
      *
      * @param parentPosition Position of the newly inserted ParentListItem in the data set, relative
      *                       to list of ParentListItems only.
@@ -656,14 +652,14 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Notify any registered observers that the currently reflected <code>itemCount</code>
-     * ParentListItems starting at <code>parentPositionStart</code> have been newly inserted.
-     * The ParentListItems previously located at <code>parentPositionStart</code> and beyond
-     * can now be found starting at position <code>parentPositionStart + itemCount</code>.
-     *
-     * <p>This is a structural change event. Representations of other existing items in the
+     * Notify any registered observers that the currently reflected {@code itemCount}
+     * ParentListItems starting at {@code parentPositionStart} have been newly inserted.
+     * The ParentListItems previously located at {@code parentPositionStart} and beyond
+     * can now be found starting at position {@code parentPositionStart + itemCount}.
+     * <p>
+     * This is a structural change event. Representations of other existing items in the
      * data set are still considered up to date and will not be rebound, though their positions
-     * may be altered.</p>
+     * may be altered.
      *
      * @param parentPositionStart Position of the first ParentListItem that was inserted, relative
      *                            to list of ParentListItems only.
@@ -706,13 +702,13 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Notify any registered observers that the ParentListItem previously located at <code>parentPosition</code>
+     * Notify any registered observers that the ParentListItem previously located at {@code parentPosition}
      * has been removed from the data set. The ParentListItems previously located at and after
-     * <code>parentPosition</code> may now be found at <code>oldPosition - 1</code>.
-     *
-     * <p>This is a structural change event. Representations of other existing items in the
+     * {@code parentPosition} may now be found at {@code oldPosition - 1}.
+     * <p>
+     * This is a structural change event. Representations of other existing items in the
      * data set are still considered up to date and will not be rebound, though their positions
-     * may be altered.</p>
+     * may be altered.
      *
      * @param parentPosition Position of the ParentListItem that has now been removed, relative
      *                       to list of ParentListItems only.
@@ -733,12 +729,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Notify any registered observers that the ParentListItem at <code>parentPosition</code> has changed.
+     * Notify any registered observers that the ParentListItem at {@code parentPosition} has changed.
      * This will also trigger an item changed for children of the ParentList specified.
-     *
-     * <p>This is an item change event, not a structural change event. It indicates that any
-     * reflection of the data at <code>parentPosition</code> is out of date and should be updated.
-     * The ParentListItem at <code>parentPosition</code> retains the same identity.</p>
+     * <p>
+     * This is an item change event, not a structural change event. It indicates that any
+     * reflection of the data at {@code parentPosition} is out of date and should be updated.
+     * The ParentListItem at {@code parentPosition} retains the same identity.
      *
      * @param parentPosition Position of the item that has changed
      */
@@ -759,19 +755,19 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Notify any registered observers that the ParentListItem reflected at <code>parentPosition</code>
-     * has a ChildItem that has been newly inserted at <code>childPosition</code>.
-     * The ChildItem previously at <code>childPosition</code> is now at
-     * position <code>childPosition + 1</code>.
-     *
-     * <p>This is a structural change event. Representations of other existing items in the
+     * Notify any registered observers that the ParentListItem reflected at {@code parentPosition}
+     * has a ChildItem that has been newly inserted at {@code childPosition}.
+     * The ChildItem previously at {@code childPosition} is now at
+     * position {@code childPosition + 1}.
+     * <p>
+     * This is a structural change event. Representations of other existing items in the
      * data set are still considered up to date and will not be rebound, though their
-     * positions may be altered.</p>
+     * positions may be altered.
      *
      * @param parentPosition Position of the ParentListItem which has been added a child, relative
      *                       to list of ParentListItems only.
      * @param childPosition Position of the child object that has been inserted, relative to children
-     *                      of the ParentListItem specified by <code>parentPosition</code> only.
+     *                      of the ParentListItem specified by {@code parentPosition} only.
      *
      */
     public void notifyChildItemInserted(int parentPosition, int childPosition) {
@@ -787,19 +783,19 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Notify any registered observers that the ParentListItem located at <code>parentPosition</code>
-     * has a ChildItem that has been removed from the data set, previously located at <code>childPosition</code>.
-     * The ChildItem previously located at and after <code>childPosition</code> may
-     * now be found at <code>childPosition - 1</code>.
-     *
-     * <p>This is a structural change event. Representations of other existing items in the
+     * Notify any registered observers that the ParentListItem located at {@code parentPosition}
+     * has a ChildItem that has been removed from the data set, previously located at {@code childPosition}.
+     * The ChildItem previously located at and after {@code childPosition} may
+     * now be found at {@code childPosition - 1}.
+     * <p>
+     * This is a structural change event. Representations of other existing items in the
      * data set are still considered up to date and will not be rebound, though their positions
-     * may be altered.</p>
+     * may be altered.
      *
      * @param parentPosition Position of the ParentListItem which has a child removed from, relative
      *                       to list of ParentListItems only.
      * @param childPosition Position of the child object that has been removed, relative to children
-     *                      of the ParentListItem specified by <code>parentPosition</code> only.
+     *                      of the ParentListItem specified by {@code parentPosition} only.
      */
     public void notifyChildItemRemoved(int parentPosition, int childPosition) {
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
@@ -812,12 +808,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Notify any registered observers that the ParentListItem at <code>parentPosition</code> has
-     * a child located at <code>childPosition</code> that has changed.
-     *
-     * <p>This is an item change event, not a structural change event. It indicates that any
-     * reflection of the data at <code>childPosition</code> is out of date and should be updated.
-     * The ParentListItem at <code>childPosition</code> retains the same identity.</p>
+     * Notify any registered observers that the ParentListItem at {@code parentPosition} has
+     * a child located at {@code childPosition} that has changed.
+     * <p>
+     * This is an item change event, not a structural change event. It indicates that any
+     * reflection of the data at {@code childPosition} is out of date and should be updated.
+     * The ParentListItem at {@code childPosition} retains the same identity.
      *
      * @param parentPosition Position of the ParentListItem who has a child that has changed
      * @param childPosition Position of the child that has changed

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -418,7 +418,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         int childCount = 0;
         Object listItem;
         ParentWrapper parentWrapper;
-        List<Object> childItemList;
+        List<?> childItemList;
         int listItemCount = mItemList.size();
         while (fullCount < listItemCount) {
             listItem = getListItem(fullCount);
@@ -532,7 +532,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
             }
 
-            List<Object> childItemList = parentWrapper.getChildItemList();
+            List<?> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
                 int childListItemCount = childItemList.size();
                 for (int i = 0; i < childListItemCount; i++) {
@@ -562,7 +562,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
             }
 
-            List<Object> childItemList = parentWrapper.getChildItemList();
+            List<?> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
                 for (int i = childItemList.size() - 1; i >= 0; i--) {
                     mItemList.remove(parentIndex + i + 1);
@@ -617,7 +617,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         mItemList.add(wrapperIndex, parentWrapper);
         if (parentWrapper.isInitiallyExpanded()) {
             parentWrapper.setExpanded(true);
-            List<Object> childItemList = parentWrapper.getChildItemList();
+            List<?> childItemList = parentWrapper.getChildItemList();
             mItemList.addAll(wrapperIndex + sizeChanged, childItemList);
             sizeChanged += childItemList.size();
         }
@@ -639,6 +639,20 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         notifyItemRangeRemoved(wrapperIndex, sizeChanged);
     }
 
+    public void notifyParentItemChanged(int parentPosition) {
+        int wrapperIndex = getParentWrapperIndex(parentPosition);
+        ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(wrapperIndex);
+        int sizeChanged = 1;
+        if (parentWrapper.isExpanded()) {
+            int childListSize = parentWrapper.getChildItemList().size();
+            for (int i = 0; i < childListSize; i++) {
+                sizeChanged++;
+            }
+        }
+
+        notifyItemRangeChanged(wrapperIndex, sizeChanged);
+    }
+
     /**
      * Adds a child to the adapter at the given positions.
      *
@@ -653,7 +667,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
         parentWrapper.setParentListItem(updatedParentListItem);
-        parentWrapper.getChildItemList().add(childPosition, child);
+//        parentWrapper.getChildItemList().add(childPosition, child);
         if (parentWrapper.isExpanded()) {
             mItemList.add(parentWrapperIndex + childPosition + 1, child);
             notifyItemInserted(parentWrapperIndex + childPosition + 1);
@@ -675,7 +689,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             return null;
         }
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
-        List<Object> childItems = parentWrapper.getChildItemList();
+        List<?> childItems = parentWrapper.getChildItemList();
         if (childPosition >= childItems.size()) {
             return null;
         }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -430,8 +430,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                     parentWrapper.setExpanded(expandedStateMap.get(fullCount - childCount));
 
 
-                    if (parentWrapper.isExpanded() && !parentWrapper.getParentListItem().isInitiallyExpanded()) {
-                        childItemList = parentWrapper.getParentListItem().getChildItemList();
+                    if (parentWrapper.isExpanded() && !parentWrapper.isInitiallyExpanded()) {
+                        childItemList = parentWrapper.getChildItemList();
 
                         if (childItemList != null) {
                             int childListItemCount = childItemList.size();
@@ -441,8 +441,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                                 mItemList.add(fullCount, childItemList.get(j));
                             }
                         }
-                    } else if (!parentWrapper.isExpanded() && parentWrapper.getParentListItem().isInitiallyExpanded()) {
-                        childItemList = parentWrapper.getParentListItem().getChildItemList();
+                    } else if (!parentWrapper.isExpanded() && parentWrapper.isInitiallyExpanded()) {
+                        childItemList = parentWrapper.getChildItemList();
                         int childListItemCount = childItemList.size();
                         for (int j = 0; j < childListItemCount; j++) {
                             mItemList.remove(fullCount + 1);
@@ -532,7 +532,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
             }
 
-            List<Object> childItemList = parentWrapper.getParentListItem().getChildItemList();
+            List<Object> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
                 int childListItemCount = childItemList.size();
                 for (int i = 0; i < childListItemCount; i++) {
@@ -562,7 +562,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
             }
 
-            List<Object> childItemList = parentWrapper.getParentListItem().getChildItemList();
+            List<Object> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
                 for (int i = childItemList.size() - 1; i >= 0; i--) {
                     mItemList.remove(parentIndex + i + 1);
@@ -635,9 +635,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         int sizeChanged = 1;
         ParentWrapper parentWrapper = new ParentWrapper(parentListItem);
         mItemList.add(wrapperIndex, parentWrapper);
-        if (parentListItem.isInitiallyExpanded()) {
+        if (parentWrapper.isInitiallyExpanded()) {
             parentWrapper.setExpanded(true);
-            List<Object> childItemList = parentListItem.getChildItemList();
+            List<Object> childItemList = parentWrapper.getChildItemList();
             mItemList.addAll(wrapperIndex + sizeChanged, childItemList);
             sizeChanged += childItemList.size();
         }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -678,7 +678,8 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         int sizeChanged = 0;
         int wrapperIndex = initialWrapperIndex;
         int changed;
-        for (int i = parentPositionStart; i < parentPositionStart + itemCount; i++) {
+        int parentPositionEnd = parentPositionStart + itemCount;
+        for (int i = parentPositionStart; i < parentPositionEnd; i++) {
             ParentListItem parentListItem = mParentItemList.get(i);
             changed = addParentWrapper(wrapperIndex, parentListItem);
             wrapperIndex += changed;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -696,6 +696,16 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         return parentListItem;
     }
 
+    /**
+     * Adds a child to the adapter at the given positions.
+     *
+     * @param parentPosition The index of the parent which will have a child added to
+     * @param childPosition The position which the child will be added relative to the child list for
+     *                      the parent specified in parentPosition
+     * @param updatedParentListItem The newly updated {@link ParentListItem} which already has the
+     *                              changed childList
+     * @param child The child object to be inserted into the adapter
+     */
     public void addChild(int parentPosition, int childPosition, ParentListItem updatedParentListItem, Object child) {
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
@@ -707,6 +717,15 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
     }
 
+    /**
+     * Removes a child from the adapter at the given positions.
+     *
+     * @param parentPosition The position of the parent which will have a child removed from
+     * @param childPosition The position of the
+     * @param updatedParentListItem The newly updated {@link ParentListItem} which already has the
+     *                              changed childList
+     * @return The child removed from the adapter, null if the child is not found
+     */
     public Object removeChild(int parentPosition, int childPosition, ParentListItem updatedParentListItem) {
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
         if (parentWrapperIndex == -1) {

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -653,55 +653,36 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         notifyItemRangeChanged(wrapperIndex, sizeChanged);
     }
 
-    /**
-     * Adds a child to the adapter at the given positions.
-     *
-     * @param parentPosition The index of the parent which will have a child added to
-     * @param childPosition The position which the child will be added relative to the child list for
-     *                      the parent specified in parentPosition
-     * @param updatedParentListItem The newly updated {@link ParentListItem} which already has the
-     *                              changed childList
-     * @param child The child object to be inserted into the adapter
-     */
-    public void addChild(int parentPosition, int childPosition, ParentListItem updatedParentListItem, Object child) {
+    public void notifyChildItemInserted(int parentPosition, int childPosition) {
+        ParentListItem parentListItem = mParentItemList.get(parentPosition);
+        Object child =  parentListItem.getChildItemList().get(childPosition);
+
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
-        parentWrapper.setParentListItem(updatedParentListItem);
-//        parentWrapper.getChildItemList().add(childPosition, child);
         if (parentWrapper.isExpanded()) {
             mItemList.add(parentWrapperIndex + childPosition + 1, child);
             notifyItemInserted(parentWrapperIndex + childPosition + 1);
         }
     }
 
-    /**
-     * Removes a child from the adapter at the given positions.
-     *
-     * @param parentPosition The position of the parent which will have a child removed from
-     * @param childPosition The position of the
-     * @param updatedParentListItem The newly updated {@link ParentListItem} which already has the
-     *                              changed childList
-     * @return The child removed from the adapter, null if the child is not found
-     */
-    public Object removeChild(int parentPosition, int childPosition, ParentListItem updatedParentListItem) {
+    public void notifyChildItemRemoved(int parentPosition, int childPosition) {
         int parentWrapperIndex = getParentWrapperIndex(parentPosition);
-        if (parentWrapperIndex == -1) {
-            return null;
-        }
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
-        List<?> childItems = parentWrapper.getChildItemList();
-        if (childPosition >= childItems.size()) {
-            return null;
-        }
 
-        Object removedChild = childItems.remove(childPosition);
         if (parentWrapper.isExpanded()) {
             mItemList.remove(parentWrapperIndex + childPosition + 1);
             notifyItemRemoved(parentWrapperIndex + childPosition + 1);
         }
-        parentWrapper.setParentListItem(updatedParentListItem);
-        return removedChild;
     }
+
+    public void notifyChildItemChanged(int parentPosition, int childPosition) {
+        int parentWrapperIndex = getParentWrapperIndex(parentPosition);
+        ParentWrapper parentWrapper = (ParentWrapper) mItemList.get(parentWrapperIndex);
+        if (parentWrapper.isExpanded()) {
+            notifyItemChanged(parentWrapperIndex + childPosition + 1);
+        }
+    }
+
 
 
     // endregion

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -40,7 +40,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     /**
      * A {@link List} of all {@link ParentListItem} objects.
      */
-    protected List<ParentListItem> mParentItemList;
+    protected List<? extends ParentListItem> mParentItemList;
 
     private ExpandCollapseListener mExpandCollapseListener;
     private List<RecyclerView> mAttachedRecyclerViewPool;
@@ -81,7 +81,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
      */
     public ExpandableRecyclerAdapter(@NonNull List<? extends ParentListItem> parentItemList) {
         super();
-        mParentItemList = new ArrayList<>(parentItemList);
+        mParentItemList = parentItemList;
         mItemList = ExpandableRecyclerAdapterHelper.generateParentChildItemList(parentItemList);
         mAttachedRecyclerViewPool = new ArrayList<>();
     }
@@ -598,36 +598,16 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
     // region Data Manipulation
 
-    /**
-     * Adds the specified {@link ParentListItem} at the end of the list.
-     *
-     * @param parentListItem The {@code ParentListItem} to add
-     */
-    public void addParent(ParentListItem parentListItem) {
-        mParentItemList.add(parentListItem);
-        addParentWrapper(mItemList.size(), parentListItem);
-    }
+    public void notifyParentItemInserted(int position) {
+        ParentListItem parentListItem = mParentItemList.get(position);
 
-    /**
-     * Inserts the specified {@link ParentListItem} into this adapter at the
-     * specified position.
-     * <p>
-     * The {@code ParentListItem} is inserted before the current element at the
-     * specified position. If the position is equal to the size of the parent
-     * list, the object is added at the end. If the position is smaller than the
-     * size of this adapter, then all elements beyond the specified position are
-     * moved by one position towards the end of the adapter.
-     *
-     * @param position The index at which to insert
-     * @param parentListItem The {@code ParentListItem} to add
-     *
-     * @throws IndexOutOfBoundsException
-     *                if {@code position < 0 || position > size()}
-     */
-    public void addParent(int position, ParentListItem parentListItem) {
-        mParentItemList.add(position, parentListItem);
+        int wrapperIndex;
+        if (position < mParentItemList.size() - 1) {
+            wrapperIndex = getParentWrapperIndex(position);
+        } else {
+            wrapperIndex = mItemList.size();
+        }
 
-        int wrapperIndex = getParentWrapperIndex(position);
         addParentWrapper(wrapperIndex, parentListItem);
     }
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -598,12 +598,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
     // region Data Manipulation
 
-    public void notifyParentItemInserted(int position) {
-        ParentListItem parentListItem = mParentItemList.get(position);
+    public void notifyParentItemInserted(int parentPosition) {
+        ParentListItem parentListItem = mParentItemList.get(parentPosition);
 
         int wrapperIndex;
-        if (position < mParentItemList.size() - 1) {
-            wrapperIndex = getParentWrapperIndex(position);
+        if (parentPosition < mParentItemList.size() - 1) {
+            wrapperIndex = getParentWrapperIndex(parentPosition);
         } else {
             wrapperIndex = mItemList.size();
         }
@@ -624,46 +624,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         notifyItemRangeInserted(wrapperIndex, sizeChanged);
     }
 
-    /**
-     * Removes the first occurrence of the specified {@link ParentListItem}
-     * from this adapter.
-     *
-     * @param parentListItem The {@code ParentListItem} to remove
-     * @return true if this adapter was modified by this operation, false
-     *         otherwise
-     */
-    public boolean removeParent(ParentListItem parentListItem) {
-
-        int index = mParentItemList.indexOf(parentListItem);
-        if (index == -1) {
-            return false;
-        }
-
-        removeParent(index);
-        return true;
-    }
-
-    /**
-     * Removes the {@link ParentListItem} at the specified location from this
-     * adapter.
-     *
-     * @param parentPosition The index of the object to remove
-     * @return The removed {@code ParentListItem}
-     * @throws IndexOutOfBoundsException
-     *                if {@code location < 0 || location >= size()}
-     */
-    public ParentListItem removeParent(int parentPosition) {
-        ParentListItem parentListItem = mParentItemList.remove(parentPosition);
-
+    public void notifyParentItemRemoved(int parentPosition) {
         int sizeChanged = 1;
         int wrapperIndex = getParentWrapperIndex(parentPosition);
-        if (wrapperIndex == -1) {
-            throw new IllegalStateException("Parent not found");
-        }
-
         ParentWrapper parentWrapper = (ParentWrapper) mItemList.remove(wrapperIndex);
         if (parentWrapper.isExpanded()) {
-            int childListSize = parentListItem.getChildItemList().size();
+            int childListSize = parentWrapper.getChildItemList().size();
             for (int i = 0; i < childListSize; i++) {
                 mItemList.remove(wrapperIndex);
                 sizeChanged++;
@@ -671,9 +637,6 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
 
         notifyItemRangeRemoved(wrapperIndex, sizeChanged);
-
-
-        return parentListItem;
     }
 
     /**

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapterHelper.java
@@ -32,12 +32,12 @@ public class ExpandableRecyclerAdapterHelper {
             parentWrapper = new ParentWrapper(parentListItem);
             parentWrapperList.add(parentWrapper);
 
-            if (parentListItem.isInitiallyExpanded()) {
+            if (parentWrapper.isInitiallyExpanded()) {
                 parentWrapper.setExpanded(true);
 
-                int childListItemCount = parentListItem.getChildItemList().size();
+                int childListItemCount = parentWrapper.getChildItemList().size();
                 for (int j = 0; j < childListItemCount; j++) {
-                    parentWrapperList.add(parentListItem.getChildItemList().get(j));
+                    parentWrapperList.add(parentWrapper.getChildItemList().get(j));
                 }
             }
         }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentListItem.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentListItem.java
@@ -14,7 +14,7 @@ public interface ParentListItem {
      *
      * @return A {@link List} of the children of this {@link ParentListItem}
      */
-    List<Object> getChildItemList();
+    List<?> getChildItemList();
 
     /**
      * Getter used to determine if this {@link ParentListItem}'s

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -1,5 +1,8 @@
 package com.bignerdranch.expandablerecyclerview.Model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Wrapper used to link expanded state with a {@link ParentListItem}.
  *
@@ -11,6 +14,8 @@ public class ParentWrapper {
 
     private boolean mExpanded;
     private ParentListItem mParentListItem;
+    private boolean mInitiallyExpanded;
+    private List<Object> mChildItemList;
 
     /**
      * Default constructor.
@@ -19,6 +24,8 @@ public class ParentWrapper {
      */
     public ParentWrapper(ParentListItem parentListItem) {
         mParentListItem = parentListItem;
+        mInitiallyExpanded = parentListItem.isInitiallyExpanded();
+        mChildItemList = new ArrayList<>(parentListItem.getChildItemList());
         mExpanded = false;
     }
 
@@ -56,5 +63,13 @@ public class ParentWrapper {
      */
     public void setExpanded(boolean expanded) {
         mExpanded = expanded;
+    }
+
+    public boolean isInitiallyExpanded() {
+        return mInitiallyExpanded;
+    }
+
+    public List<Object> getChildItemList() {
+        return mChildItemList;
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Model/ParentWrapper.java
@@ -1,6 +1,5 @@
 package com.bignerdranch.expandablerecyclerview.Model;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -14,8 +13,6 @@ public class ParentWrapper {
 
     private boolean mExpanded;
     private ParentListItem mParentListItem;
-    private boolean mInitiallyExpanded;
-    private List<Object> mChildItemList;
 
     /**
      * Default constructor.
@@ -24,8 +21,6 @@ public class ParentWrapper {
      */
     public ParentWrapper(ParentListItem parentListItem) {
         mParentListItem = parentListItem;
-        mInitiallyExpanded = parentListItem.isInitiallyExpanded();
-        mChildItemList = new ArrayList<>(parentListItem.getChildItemList());
         mExpanded = false;
     }
 
@@ -66,10 +61,10 @@ public class ParentWrapper {
     }
 
     public boolean isInitiallyExpanded() {
-        return mInitiallyExpanded;
+        return mParentListItem.isInitiallyExpanded();
     }
 
-    public List<Object> getChildItemList() {
-        return mChildItemList;
+    public List<?> getChildItemList() {
+        return mParentListItem.getChildItemList();
     }
 }


### PR DESCRIPTION
Fixes #73 by relaxing the object reference in the child list

Removes add/remove methods and instead gives the user a set of notifyParentItem/notifyChildItem to notify the adapter of changes to the ParentItemList. Base Adapter notify methods are not supported.

In this PR the following are implemented:
```java
// ParentChanges
notifyParentItemInserted(int parentPosition)}
notifyParentItemRemoved(int parentPosition)}
notifyParentItemChanged(int parentPosition)}
notifyParentItemRangeInserted(int parentPositionStart, int itemCount)}
// Child Changes
notifyChildItemInserted(int parentPosition, int childPosition)}
notifyChildItemRemoved(int parentPosition, int childPosition)}
notifyChildItemChanged(int parentPosition, int childPosition)}
```