### PR TITLE
Clarified comment in ParentViewHolder

### DIFF
--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ViewHolder/ParentViewHolder.java
@@ -83,7 +83,8 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
      * <p>
      * Useful for implementing animations on expansion.
      *
-     * @param expanded true if expanded, false if not
+     * @param expanded true if view is expanded before expansion is toggled,
+     *                 false if not
      */
     public void onExpansionToggled(boolean expanded) {
 


### PR DESCRIPTION
Resolves #103.

Because we're discussing a change in state, we should specify that the `expanded` parameter refers to the state of the view _before_ the state change.