### PR TITLE
Fix listner callback timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 2.0.3 (10/14/15)
+----------------------------
+- Change `onListItemExpanded` and `onListItemCollapsed` to be called after list is updated, fixes bug in issue #112
+
 Version 2.0.2 (10/13/15)
 ----------------------------
 - Fix `notifyChildItemChanged` and `notifyParentItemChanged`, previously child objects were not being replaced

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 ##Project Setup
 **Gradle**
 
-The [latest release](https://github.com/bignerdranch/expandable-recycler-view/releases/tag/v2.0.2) can be used by adding the following to your app's build.gradle:
+The [latest release](https://github.com/bignerdranch/expandable-recycler-view/releases/tag/v2.0.3) can be used by adding the following to your app's build.gradle:
 ```gradle
-compile 'com.bignerdranch.android:expandablerecyclerview:2.0.2'
+compile 'com.bignerdranch.android:expandablerecyclerview:2.0.3'
 ```
 
 ## Overview

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -548,11 +548,6 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         if (!parentWrapper.isExpanded()) {
             parentWrapper.setExpanded(true);
 
-            if (expansionTriggeredByListItemClick && mExpandCollapseListener != null) {
-                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
-                mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
-            }
-
             List<?> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
                 int childListItemCount = childItemList.size();
@@ -560,6 +555,11 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                     mItemList.add(parentIndex + i + 1, childItemList.get(i));
                     notifyItemInserted(parentIndex + i + 1);
                 }
+            }
+
+            if (expansionTriggeredByListItemClick && mExpandCollapseListener != null) {
+                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
+                mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
             }
         }
     }
@@ -578,17 +578,17 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         if (parentWrapper.isExpanded()) {
             parentWrapper.setExpanded(false);
 
-            if (collapseTriggeredByListItemClick && mExpandCollapseListener != null) {
-                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
-                mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
-            }
-
             List<?> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
                 for (int i = childItemList.size() - 1; i >= 0; i--) {
                     mItemList.remove(parentIndex + i + 1);
                     notifyItemRemoved(parentIndex + i + 1);
                 }
+            }
+
+            if (collapseTriggeredByListItemClick && mExpandCollapseListener != null) {
+                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
+                mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=2.0.2
-VERSION_CODE=4
+VERSION_NAME=2.0.3
+VERSION_CODE=5
 GROUP=com.bignerdranch.android
 
 POM_DESCRIPTION=A lightweight Android library that allows for the expansion and collapsing of RecyclerView items


### PR DESCRIPTION
fixes #112 
Calling `onListItemExpanded\Collapsed` before the list was updated in the adapter caused weird behaviour for users when they changed some of the data and notified the adapter.