### PR TITLE
Reduced frequency of notify calls in expand/collpase methods

### DIFF
--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -558,8 +558,9 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 int childListItemCount = childItemList.size();
                 for (int i = 0; i < childListItemCount; i++) {
                     mItemList.add(parentIndex + i + 1, childItemList.get(i));
-                    notifyItemInserted(parentIndex + i + 1);
                 }
+
+                notifyItemRangeInserted(parentIndex + 1, childListItemCount);
             }
         }
     }
@@ -585,10 +586,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
             List<?> childItemList = parentWrapper.getChildItemList();
             if (childItemList != null) {
-                for (int i = childItemList.size() - 1; i >= 0; i--) {
+                int childListItemCount = childItemList.size();
+                for (int i = childListItemCount - 1; i >= 0; i--) {
                     mItemList.remove(parentIndex + i + 1);
-                    notifyItemRemoved(parentIndex + i + 1);
                 }
+
+                notifyItemRangeRemoved(parentIndex + 1, childListItemCount);
             }
         }
     }


### PR DESCRIPTION
Resolves #72.

Replaced `RecyclerView#notifyItemInserted()` calls with `RecyclerView#notifyItemRangeInserted()` calls to the number of notify calls from _number_of_children_ to 1. 

Also reduces the number of notify calls made when calling `ExpandableRecyclerAdapter#expandAllParents()` and `ExpandableRecyclerAdapter#collapseAllParents()` from _(number_of_parents * number_of_children)_ to _number_of_parents_.