### PR TITLE
Ability to access parent and child information associated with a ViewHolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Version 3.0.0 SNAPSHOT
+----------------------------
+- Added ParentViewHolder methods:
+    - `getParentListItem()`
+    - `getParentAdapterPosition()`
+- Added ChildViewHolder methods:
+    - `getChildListItem()`
+    - `getParentAdapterPosition()`
+    - `getChildAdapterPosition()`
+
 Version 2.1.1 (2/26/16)
 ----------------------------
 - Updated Support Library dependencies

--- a/README.md
+++ b/README.md
@@ -8,25 +8,21 @@ A custom RecyclerView which allows for an expandable view to be attached to each
 
 For more information please see [the website](http://bignerdranch.github.io/expandable-recycler-view/).
 
-##Download
-
-[v2.1.1 AAR](http://repo1.maven.org/maven2/com/bignerdranch/android/expandablerecyclerview/2.1.1/expandablerecyclerview-2.1.1.aar)
-
 **Gradle**
+This version is still in development, feel free to test it out by adding the following to your app's `build.gradle`:
 
 ```
-compile 'com.bignerdranch.android:expandablerecyclerview:2.1.1'
+compile 'com.bignerdranch.android:expandablerecyclerview:3.0.0-SNAPSHOT'
 ```
 
-**Maven**
-
-```
-<dependency>
-  <groupId>com.bignerdranch.android</groupId>
-  <artifactId>expandablerecyclerview</artifactId>
-  <version>2.1.1</version>
-</dependency>
-```
+Add Sonatype's snapshots to your repositories closure in the root `build.gradle`:
+ ```gradle
+ allprojects {
+     repositories {
+         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+     }
+ }
+ ```
 
 ##License
 

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeChildViewHolder.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeChildViewHolder.java
@@ -4,7 +4,7 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ChildViewHolder;
+import com.bignerdranch.expandablerecyclerview.ChildViewHolder;
 
 /**
  * Created by ryanbrooks on 6/17/15.

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeExpandableAdapter.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeExpandableAdapter.java
@@ -5,7 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
+import com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter;
 import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 
 import java.util.List;

--- a/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeParentViewHolder.java
+++ b/criminalintentsample/src/main/java/com/bignerdranch/android/criminalintent/CrimeParentViewHolder.java
@@ -6,7 +6,7 @@ import android.view.View;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
+import com.bignerdranch.expandablerecyclerview.ParentViewHolder;
 
 public class CrimeParentViewHolder extends ParentViewHolder {
     private static final float INITIAL_POSITION = 0.0f;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ChildViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ChildViewHolder.java
@@ -1,18 +1,13 @@
-package com.bignerdranch.expandablerecyclerview.ViewHolder;
+package com.bignerdranch.expandablerecyclerview;
 
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 /**
- * ViewHolder for a child list
- * item.
+ * ViewHolder for a child list item.
  * <p>
  * The user should extend this class and implement as they wish for their
  * child list item.
- *
- * @author Ryan Brooks
- * @version 1.0
- * @since 5/27/2015
  */
 public class ChildViewHolder extends RecyclerView.ViewHolder {
 

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ChildViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ChildViewHolder.java
@@ -11,6 +11,9 @@ import android.view.View;
  */
 public class ChildViewHolder extends RecyclerView.ViewHolder {
 
+    Object mChildListItem;
+    ExpandableRecyclerAdapter mExpandableAdapter;
+
     /**
      * Default constructor.
      *
@@ -18,5 +21,48 @@ public class ChildViewHolder extends RecyclerView.ViewHolder {
      */
     public ChildViewHolder(View itemView) {
         super(itemView);
+    }
+
+    /**
+     * @return the childListItem associated with this view holder
+     */
+    public Object getChildListItem() {
+        return mChildListItem;
+    }
+
+    /**
+     *
+     * Returns the adapter position of the Parent associated with this ChildViewHolder
+     *
+     * @return The adapter position of the Parent if it still exists in the adapter.
+     * RecyclerView.NO_POSITION if item has been removed from the adapter,
+     * RecyclerView.Adapter.notifyDataSetChanged() has been called after the last
+     * layout pass or the ViewHolder has already been recycled.
+     */
+    public int getParentAdapterPosition() {
+        int adapterPosition = getAdapterPosition();
+        if (adapterPosition == RecyclerView.NO_POSITION) {
+            return adapterPosition;
+        }
+
+        return mExpandableAdapter.getNearestParentPosition(adapterPosition);
+    }
+
+    /**
+     *
+     * Returns the adapter position of the Child associated with this ChildViewHolder
+     *
+     * @return The adapter position of the Child if it still exists in the adapter.
+     * RecyclerView.NO_POSITION if item has been removed from the adapter,
+     * RecyclerView.Adapter.notifyDataSetChanged() has been called after the last
+     * layout pass or the ViewHolder has already been recycled.
+     */
+    public int getChildAdapterPosition() {
+        int adapterPosition = getAdapterPosition();
+        if (adapterPosition == RecyclerView.NO_POSITION) {
+            return adapterPosition;
+        }
+
+        return mExpandableAdapter.getChildPosition(adapterPosition);
     }
 }

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapter.java
@@ -1,4 +1,4 @@
-package com.bignerdranch.expandablerecyclerview.Adapter;
+package com.bignerdranch.expandablerecyclerview;
 
 import android.app.Activity;
 import android.os.Bundle;
@@ -8,8 +8,6 @@ import android.view.ViewGroup;
 
 import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import com.bignerdranch.expandablerecyclerview.Model.ParentWrapper;
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ChildViewHolder;
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -246,7 +244,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Implementation of {@link com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder.ParentListItemExpandCollapseListener#onParentListItemExpanded(int)}.
+     * Implementation of {@link com.bignerdranch.expandablerecyclerview.ParentViewHolder.ParentListItemExpandCollapseListener#onParentListItemExpanded(int)}.
      * <p>
      * Called when a {@link ParentListItem} is triggered to expand.
      *
@@ -261,7 +259,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
     }
 
     /**
-     * Implementation of {@link com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder.ParentListItemExpandCollapseListener#onParentListItemCollapsed(int)}.
+     * Implementation of {@link com.bignerdranch.expandablerecyclerview.ParentViewHolder.ParentListItemExpandCollapseListener#onParentListItemCollapsed(int)}.
      * <p>
      * Called when a {@link ParentListItem} is triggered to collapse.
      *

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapter.java
@@ -107,9 +107,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         if (viewType == TYPE_PARENT) {
             PVH pvh = onCreateParentViewHolder(viewGroup);
             pvh.setParentListItemExpandCollapseListener(this);
+            pvh.mExpandableAdapter = this;
             return pvh;
         } else if (viewType == TYPE_CHILD) {
-            return onCreateChildViewHolder(viewGroup);
+            CVH cvh = onCreateChildViewHolder(viewGroup);
+            cvh.mExpandableAdapter = this;
+            return cvh;
         } else {
             throw new IllegalStateException("Incorrect ViewType found");
         }
@@ -138,11 +141,14 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
 
             ParentWrapper parentWrapper = (ParentWrapper) listItem;
             parentViewHolder.setExpanded(parentWrapper.isExpanded());
+            parentViewHolder.mParentWrapper = parentWrapper;
             onBindParentViewHolder(parentViewHolder, position, parentWrapper.getParentListItem());
         } else if (listItem == null) {
             throw new IllegalStateException("Incorrect ViewHolder found");
         } else {
-            onBindChildViewHolder((CVH) holder, position, listItem);
+            CVH childViewHolder = (CVH) holder;
+            childViewHolder.mChildListItem = listItem;
+            onBindChildViewHolder(childViewHolder, position, listItem);
         }
     }
 
@@ -575,8 +581,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             }
 
             if (expansionTriggeredByListItemClick && mExpandCollapseListener != null) {
-                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
-                mExpandCollapseListener.onListItemExpanded(parentIndex - expandedCountBeforePosition);
+                mExpandCollapseListener.onListItemExpanded(getNearestParentPosition(parentIndex));
             }
         }
     }
@@ -606,32 +611,52 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
             }
 
             if (collapseTriggeredByListItemClick && mExpandCollapseListener != null) {
-                int expandedCountBeforePosition = getExpandedItemCount(parentIndex);
-                mExpandCollapseListener.onListItemCollapsed(parentIndex - expandedCountBeforePosition);
+                mExpandCollapseListener.onListItemCollapsed(getNearestParentPosition(parentIndex));
             }
         }
     }
 
     /**
-     * Gets the number of expanded child list items before the specified position.
+     * Given the index relative to the entire RecyclerView, returns the nearest
+     * ParentPosition without going past the given index.
      *
-     * @param position The index before which to return the number of expanded
-     *                 child list items
-     * @return The number of expanded child list items before the specified position
+     * If it is the index of a parent item, will return the corresponding parent position.
+     * If it is the index of a child item within the RV, will return the position of that childs parent.
      */
-    private int getExpandedItemCount(int position) {
-        if (position == 0) {
+    int getNearestParentPosition(int fullPosition) {
+        if (fullPosition == 0) {
             return 0;
         }
 
-        int expandedCount = 0;
-        for (int i = 0; i < position; i++) {
+        int parentCount = -1;
+        for (int i = 0; i <= fullPosition; i++) {
             Object listItem = getListItem(i);
-            if (!(listItem instanceof ParentWrapper)) {
-                expandedCount++;
+            if (listItem instanceof ParentWrapper) {
+                parentCount++;
             }
         }
-        return expandedCount;
+        return parentCount;
+    }
+
+    /**
+     * Given the index relative to the entire RecyclerView for a child item,
+     * returns the child position within the child list of the parent.
+     */
+    int getChildPosition(int fullPosition) {
+        if (fullPosition == 0) {
+            return 0;
+        }
+
+        int childCount = 0;
+        for (int i = 0; i < fullPosition; i++) {
+            Object listItem = getListItem(i);
+            if (listItem instanceof ParentWrapper) {
+                childCount = 0;
+            } else {
+                childCount++;
+            }
+        }
+        return childCount;
     }
 
     // endregion

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterHelper.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterHelper.java
@@ -1,4 +1,4 @@
-package com.bignerdranch.expandablerecyclerview.Adapter;
+package com.bignerdranch.expandablerecyclerview;
 
 import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import com.bignerdranch.expandablerecyclerview.Model.ParentWrapper;

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ParentViewHolder.java
@@ -3,6 +3,9 @@ package com.bignerdranch.expandablerecyclerview;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
+import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
+import com.bignerdranch.expandablerecyclerview.Model.ParentWrapper;
+
 
 /**
  * ViewHolder for a {@link com.bignerdranch.expandablerecyclerview.Model.ParentListItem}
@@ -17,6 +20,8 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
 
     private ParentListItemExpandCollapseListener mParentListItemExpandCollapseListener;
     private boolean mExpanded;
+    ParentWrapper mParentWrapper;
+    ExpandableRecyclerAdapter mExpandableAdapter;
 
     /**
      * Empowers {@link com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter}
@@ -47,6 +52,35 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     public ParentViewHolder(View itemView) {
         super(itemView);
         mExpanded = false;
+    }
+
+    /**
+     * @return the ParentListItem associated with this ViewHolder
+     */
+    public ParentListItem getParentListItem() {
+        if (mParentWrapper == null) {
+            return null;
+        }
+
+        return mParentWrapper.getParentListItem();
+    }
+
+    /**
+     *
+     * Returns the adapter position of the Parent associated with this ParentViewHolder
+     *
+     * @return The adapter position of the Parent if it still exists in the adapter.
+     * RecyclerView.NO_POSITION if item has been removed from the adapter,
+     * RecyclerView.Adapter.notifyDataSetChanged() has been called after the last
+     * layout pass or the ViewHolder has already been recycled.
+     */
+    public int getParentAdapterPosition() {
+        int adapterPosition = getAdapterPosition();
+        if (adapterPosition == RecyclerView.NO_POSITION) {
+            return adapterPosition;
+        }
+
+        return mExpandableAdapter.getNearestParentPosition(adapterPosition);
     }
 
     /**

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ParentViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ParentViewHolder.java
@@ -1,4 +1,4 @@
-package com.bignerdranch.expandablerecyclerview.ViewHolder;
+package com.bignerdranch.expandablerecyclerview;
 
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -19,7 +19,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
     private boolean mExpanded;
 
     /**
-     * Empowers {@link com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter}
+     * Empowers {@link com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter}
      * implementations to be notified of expand/collapse state change events.
      */
     public interface ParentListItemExpandCollapseListener {
@@ -92,7 +92,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
 
     /**
      * Getter for the {@link ParentListItemExpandCollapseListener} implemented in
-     * {@link com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter}.
+     * {@link com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter}.
      *
      * @return The {@link ParentListItemExpandCollapseListener} set in the {@link ParentViewHolder}
      */
@@ -102,7 +102,7 @@ public class ParentViewHolder extends RecyclerView.ViewHolder implements View.On
 
     /**
      * Setter for the {@link ParentListItemExpandCollapseListener} implemented in
-     * {@link com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter}.
+     * {@link com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter}.
      *
      * @param parentListItemExpandCollapseListener The {@link ParentListItemExpandCollapseListener} to set on the {@link ParentViewHolder}
      */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=2.1.1
-VERSION_CODE=8
+VERSION_NAME=3.0.0-SNAPHSOT
+VERSION_CODE=9
 GROUP=com.bignerdranch.android
 
 POM_DESCRIPTION=A lightweight Android library that allows for the expansion and collapsing of RecyclerView items

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChild.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChild.java
@@ -23,4 +23,9 @@ public class HorizontalChild implements Serializable {
     public void setChildText(String childText) {
         mChildText = childText;
     }
+
+    @Override
+    public String toString() {
+        return mChildText;
+    }
 }

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChildViewHolder.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChildViewHolder.java
@@ -3,7 +3,7 @@ package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 import android.view.View;
 import android.widget.TextView;
 
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ChildViewHolder;
+import com.bignerdranch.expandablerecyclerview.ChildViewHolder;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 /**

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChildViewHolder.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalChildViewHolder.java
@@ -1,5 +1,6 @@
 package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
@@ -14,6 +15,8 @@ import com.ryanbrooks.expandablerecyclerviewsample.R;
  */
 public class HorizontalChildViewHolder extends ChildViewHolder {
 
+    private static final String TAG = "HorizontalChildVH";
+
     public TextView mDataTextView;
 
     /**
@@ -25,6 +28,13 @@ public class HorizontalChildViewHolder extends ChildViewHolder {
         super(itemView);
 
         mDataTextView = (TextView) itemView.findViewById(R.id.list_item_horizontal_child_textView);
+        itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d(TAG, "Child at " + getChildAdapterPosition() + ", with parent at " + getParentAdapterPosition()
+                        + " clicked, child item is \"" + getChildListItem() + "\"");
+            }
+        });
     }
 
     public void bind(String childText) {

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalExpandableAdapter.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalExpandableAdapter.java
@@ -5,7 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
+import com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter;
 import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalLinearRecyclerViewSampleActivity.java
@@ -12,7 +12,7 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.Toast;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
+import com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 import java.util.ArrayList;

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParent.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParent.java
@@ -65,4 +65,9 @@ public class HorizontalParent implements ParentListItem, Serializable {
     public void setInitiallyExpanded(boolean initiallyExpanded) {
         mInitiallyExpanded = initiallyExpanded;
     }
+
+    @Override
+    public String toString() {
+        return mParentText;
+    }
 }

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -3,6 +3,7 @@ package com.ryanbrooks.expandablerecyclerviewsample.linear.horizontal;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;
+import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.animation.RotateAnimation;
@@ -26,6 +27,7 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
     private static final float PIVOT_VALUE = 0.5f;
     private static final long DEFAULT_ROTATE_DURATION_MS = 200;
     private static final boolean HONEYCOMB_AND_ABOVE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
+    private static final String TAG = "HorizontalParentVH";
 
     public TextView mNumberTextView;
     public TextView mDataTextView;
@@ -57,6 +59,7 @@ public class HorizontalParentViewHolder extends ParentViewHolder {
         itemView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+                Log.d(TAG, "Parent at " + getParentAdapterPosition() + " clicked, parent item is \"" + getParentListItem() + "\"");
                 Toast.makeText(context, "This sample shows how to make a row only expand upon clicking our custom arrow view", Toast.LENGTH_SHORT).show();
             }
         });

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/horizontal/HorizontalParentViewHolder.java
@@ -10,7 +10,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
+import com.bignerdranch.expandablerecyclerview.ParentViewHolder;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 /**

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/IngredientViewHolder.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/IngredientViewHolder.java
@@ -3,7 +3,7 @@ package com.ryanbrooks.expandablerecyclerviewsample.linear.vertical;
 import android.view.View;
 import android.widget.TextView;
 
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ChildViewHolder;
+import com.bignerdranch.expandablerecyclerview.ChildViewHolder;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 public class IngredientViewHolder extends ChildViewHolder {

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/RecipeAdapter.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/RecipeAdapter.java
@@ -6,7 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
+import com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter;
 import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/RecipeViewHolder.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/RecipeViewHolder.java
@@ -7,7 +7,7 @@ import android.view.animation.RotateAnimation;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
+import com.bignerdranch.expandablerecyclerview.ParentViewHolder;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 public class RecipeViewHolder extends ParentViewHolder {

--- a/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
+++ b/sampleapp/src/main/java/com/ryanbrooks/expandablerecyclerviewsample/linear/vertical/VerticalLinearRecyclerViewSampleActivity.java
@@ -9,7 +9,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.widget.Toast;
 
-import com.bignerdranch.expandablerecyclerview.Adapter.ExpandableRecyclerAdapter;
+import com.bignerdranch.expandablerecyclerview.ExpandableRecyclerAdapter;
 import com.ryanbrooks.expandablerecyclerviewsample.R;
 
 import java.util.Arrays;


### PR DESCRIPTION
Had to do some package reshuffling so this will likely mean 3.0.0

Tries to address the needs of #157 and other associated issues.

ParentViewHolder now has:
`getParentListItem()`
`getAdapterParentPosition()`

ChildViewHolder now has:
`getChildListItem()`
`getAdapterParentPosition()`
`getAdapterChildPosition()`

Still TODO:
- [x] javadocs
- [x] version bump
- [x] snapshot info