### PR TITLE
Adapter Notify Tests & expansion/collapsing via object ref

### DIFF
--- a/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
+++ b/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
@@ -156,7 +156,7 @@ public class ExpandableRecyclerAdapterTest {
     }
 
     @Test
-    public void expandingParentAddsChildren() {
+    public void expandingParentWithIndexAddsChildren() {
         ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
 
         assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
@@ -177,7 +177,28 @@ public class ExpandableRecyclerAdapterTest {
     }
 
     @Test
-    public void expandingExpandedParentHasNoEffect() {
+    public void expandingParentWithObjectAddsChildren() {
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(mBaseParentItems.get(9), parentWrapper.getParentListItem());
+        assertFalse(parentWrapper.isExpanded());
+
+        mExpandableRecyclerAdapter.expandParent(mBaseParentItems.get(9));
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
+        ParentListItem lastParentListItem = mBaseParentItems.get(9);
+
+        verify(mDataObserver).onItemRangeInserted(25, 3);
+        assertEquals(28, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(lastParentListItem, parentWrapper.getParentListItem());
+        assertEquals(lastParentListItem.getChildItemList().get(0), mExpandableRecyclerAdapter.getListItem(25));
+        assertEquals(lastParentListItem.getChildItemList().get(1), mExpandableRecyclerAdapter.getListItem(26));
+        assertEquals(lastParentListItem.getChildItemList().get(2), mExpandableRecyclerAdapter.getListItem(27));
+        assertTrue(parentWrapper.isExpanded());
+    }
+
+    @Test
+    public void expandingExpandedWithIndexParentHasNoEffect() {
         ParentListItem firstParentListItem = mBaseParentItems.get(0);
         ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
 
@@ -187,6 +208,26 @@ public class ExpandableRecyclerAdapterTest {
         assertTrue(parentWrapper.isExpanded());
 
         mExpandableRecyclerAdapter.expandParent(0);
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+
+        verify(mDataObserver, never()).onItemRangeInserted(anyInt(), anyInt());
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(firstParentListItem, parentWrapper.getParentListItem());
+        assertEquals(firstParentListItem.getChildItemList().get(0), mExpandableRecyclerAdapter.getListItem(1));
+        assertTrue(parentWrapper.isExpanded());
+    }
+
+    @Test
+    public void expandingExpandedWithObjectParentHasNoEffect() {
+        ParentListItem firstParentListItem = mBaseParentItems.get(0);
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(firstParentListItem, parentWrapper.getParentListItem());
+        assertEquals(firstParentListItem.getChildItemList().get(0), mExpandableRecyclerAdapter.getListItem(1));
+        assertTrue(parentWrapper.isExpanded());
+
+        mExpandableRecyclerAdapter.expandParent(firstParentListItem);
         parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
 
         verify(mDataObserver, never()).onItemRangeInserted(anyInt(), anyInt());

--- a/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
+++ b/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
@@ -283,6 +283,40 @@ public class ExpandableRecyclerAdapterTest {
         assertEquals(childObjects.get(2), mExpandableRecyclerAdapter.getListItem(28));
     }
 
+    @Test
+    public void notifyParentItemRemovedOnExpandedItem() {
+        ParentListItem removedItem = mBaseParentItems.get(0);
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(removedItem, parentWrapper.getParentListItem());
+
+        mBaseParentItems.remove(0);
+        mExpandableRecyclerAdapter.notifyParentItemRemoved(0);
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+
+        verify(mDataObserver).onItemRangeRemoved(0, 4);
+        assertEquals(21, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(mBaseParentItems.get(0), parentWrapper.getParentListItem());
+    }
+
+    @Test
+    public void notifyParentItemRemovedOnCollapsedItem() {
+        ParentListItem removedItem = mBaseParentItems.get(9);
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(removedItem, parentWrapper.getParentListItem());
+
+        mBaseParentItems.remove(9);
+        mExpandableRecyclerAdapter.notifyParentItemRemoved(9);
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(20);
+
+        verify(mDataObserver).onItemRangeRemoved(24, 1);
+        assertEquals(24, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(mBaseParentItems.get(8), parentWrapper.getParentListItem());
+    }
+
 
     private static class TestExpandableRecyclerAdapter extends ExpandableRecyclerAdapter<ParentViewHolder, ChildViewHolder> {
 

--- a/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
+++ b/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
@@ -76,7 +76,7 @@ public class ExpandableRecyclerAdapterTest {
     }
 
     @Test
-    public void collapsingExpandedParentRemovesChildren() {
+    public void collapsingExpandedParentWithIndexRemovesChildren() {
         ParentListItem firstParentListItem = mBaseParentItems.get(0);
         ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
 
@@ -99,7 +99,30 @@ public class ExpandableRecyclerAdapterTest {
     }
 
     @Test
-    public void collapsingCollapsedParentHasNoEffect() {
+    public void collapsingExpandedParentWithObjectRemovesChildren() {
+        ParentListItem firstParentListItem = mBaseParentItems.get(0);
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(firstParentListItem, parentWrapper.getParentListItem());
+        assertEquals(firstParentListItem.getChildItemList().get(0), mExpandableRecyclerAdapter.getListItem(1));
+        assertEquals(firstParentListItem.getChildItemList().get(1), mExpandableRecyclerAdapter.getListItem(2));
+        assertEquals(firstParentListItem.getChildItemList().get(2), mExpandableRecyclerAdapter.getListItem(3));
+        assertTrue(parentWrapper.isExpanded());
+
+        mExpandableRecyclerAdapter.collapseParent(firstParentListItem);
+        ParentWrapper firstParentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+        ParentWrapper secondParentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(1);
+
+        verify(mDataObserver).onItemRangeRemoved(1, 3);
+        assertEquals(22, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(mBaseParentItems.get(0), firstParentWrapper.getParentListItem());
+        assertEquals(mBaseParentItems.get(1), secondParentWrapper.getParentListItem());
+        assertFalse(parentWrapper.isExpanded());
+    }
+
+    @Test
+    public void collapsingCollapsedParentWithIndexHasNoEffect() {
         ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
 
         assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
@@ -107,6 +130,23 @@ public class ExpandableRecyclerAdapterTest {
         assertFalse(parentWrapper.isExpanded());
 
         mExpandableRecyclerAdapter.collapseParent(9);
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
+
+        verify(mDataObserver, never()).onItemRangeRemoved(anyInt(), anyInt());
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(mBaseParentItems.get(9), parentWrapper.getParentListItem());
+        assertFalse(parentWrapper.isExpanded());
+    }
+
+    @Test
+    public void collapsingCollapsedParentWithObjectHasNoEffect() {
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(mBaseParentItems.get(9), parentWrapper.getParentListItem());
+        assertFalse(parentWrapper.isExpanded());
+
+        mExpandableRecyclerAdapter.collapseParent(mBaseParentItems.get(9));
         parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
 
         verify(mDataObserver, never()).onItemRangeRemoved(anyInt(), anyInt());

--- a/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
+++ b/expandablerecyclerview/src/test/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapterTest.java
@@ -156,8 +156,51 @@ public class ExpandableRecyclerAdapterTest {
         assertTrue(parentWrapper.isExpanded());
     }
 
+    @Test
+    public void notifyParentItemInsertedWithInitiallyCollapsedItem() {
+        ParentListItem firstParentListItem = mBaseParentItems.get(0);
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
 
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(firstParentListItem, parentWrapper.getParentListItem());
 
+        ParentListItem insertedItem = mock(ParentListItem.class);
+        when(insertedItem.isInitiallyExpanded()).thenReturn(false);
+        mBaseParentItems.add(0, insertedItem);
+        mExpandableRecyclerAdapter.notifyParentItemInserted(0);
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(0);
+
+        verify(mDataObserver).onItemRangeInserted(0, 1);
+        assertEquals(26, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(insertedItem, parentWrapper.getParentListItem());
+    }
+
+    @Test
+    public void notifyParentItemInsertedWithInitiallyExpandedItem() {
+        List<Object> childObjects = new ArrayList<>();
+        childObjects.add(new Object());
+        childObjects.add(new Object());
+        childObjects.add(new Object());
+        ParentListItem lastParentListItem = mBaseParentItems.get(9);
+        ParentWrapper parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(24);
+
+        assertEquals(25, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(lastParentListItem, parentWrapper.getParentListItem());
+
+        ParentListItem insertedItem = mock(ParentListItem.class);
+        Mockito.<List<?>>when(insertedItem.getChildItemList()).thenReturn(childObjects);
+        when(insertedItem.isInitiallyExpanded()).thenReturn(true);
+        mBaseParentItems.add(insertedItem);
+        mExpandableRecyclerAdapter.notifyParentItemInserted(10);
+        parentWrapper = (ParentWrapper) mExpandableRecyclerAdapter.getListItem(25);
+
+        verify(mDataObserver).onItemRangeInserted(25, 4);
+        assertEquals(29, mExpandableRecyclerAdapter.getItemCount());
+        assertEquals(insertedItem, parentWrapper.getParentListItem());
+        assertEquals(childObjects.get(0), mExpandableRecyclerAdapter.getListItem(26));
+        assertEquals(childObjects.get(1), mExpandableRecyclerAdapter.getListItem(27));
+        assertEquals(childObjects.get(2), mExpandableRecyclerAdapter.getListItem(28));
+    }
 
 
     private static class TestExpandableRecyclerAdapter extends ExpandableRecyclerAdapter<ParentViewHolder, ChildViewHolder> {


### PR DESCRIPTION
Added some tests for the notify parent item added and removed, as well as the object variant of expand/collapse