### PR TITLE
-force parent item's onBindViewHolder to be called

### DIFF
--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -1,5 +1,9 @@
 package com.bignerdranch.expandablerecyclerview.Adapter;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -10,10 +14,6 @@ import com.bignerdranch.expandablerecyclerview.Model.ParentListItem;
 import com.bignerdranch.expandablerecyclerview.Model.ParentWrapper;
 import com.bignerdranch.expandablerecyclerview.ViewHolder.ChildViewHolder;
 import com.bignerdranch.expandablerecyclerview.ViewHolder.ParentViewHolder;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 /**
  * RecyclerView.Adapter implementation that
@@ -605,6 +605,7 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 }
 
                 notifyItemRangeRemoved(parentIndex + 1, childListItemCount);
+                notifyItemChanged(parentIndex, null); // this call will force trigger onBindViewHolder(), in case the parent item needs to refresh UI to display different state when open and closed
             }
 
             if (collapseTriggeredByListItemClick && mExpandCollapseListener != null) {


### PR DESCRIPTION
In some cases, the parent item needs to display different content when it's opened or closed, for example, expanding or collapsing icons. Calling notifyItemChanged(parentIndex, null) to force the parent item to refresh when collapsing. 