### PR TITLE
javadoc updates for release

### DIFF
--- a/expandablerecyclerview/build.gradle
+++ b/expandablerecyclerview/build.gradle
@@ -31,3 +31,7 @@ dependencies {
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+
+afterEvaluate {
+    androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+}

--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/ExpandableRecyclerAdapter.java
@@ -154,8 +154,8 @@ public abstract class ExpandableRecyclerAdapter<P extends Parent<C>, C, PVH exte
      * Implementation of Adapter.onBindViewHolder(RecyclerView.ViewHolder, int)
      * that determines if the list item is a parent or a child and calls through
      * to the appropriate implementation of either
-     * {@link #onBindParentViewHolder(ParentViewHolder, int, P)} or
-     * {@link #onBindChildViewHolder(ChildViewHolder, int, int, C)}.
+     * {@link #onBindParentViewHolder(ParentViewHolder, int, Parent)} or
+     * {@link #onBindChildViewHolder(ChildViewHolder, int, int, Object)}.
      *
      * @param holder The RecyclerView.ViewHolder to bind data to
      * @param flatPosition The index in the merged list of children and parents at which to bind


### PR DESCRIPTION
Some support library bits were missing for javadoc generation, this allows it to be included. Also was failing to reference the methods by their generics.